### PR TITLE
Alphanumeric registration support

### DIFF
--- a/constants_and_globals.h
+++ b/constants_and_globals.h
@@ -40,7 +40,7 @@ extern bool  LOWEST_TEST_COUNTS_HALF;
 extern int QUIZ_NORMALIZE_AND_DROP;
 
 // ==========================================================
-extern std::map<int,std::string> sectionNames;
+extern std::map<std::string,std::string> sectionNames;
 extern std::map<std::string,std::string> sectionColors;
 
 
@@ -62,7 +62,7 @@ extern float MAX_ICLICKER_TOTAL;
 // ==========================================================
 // PROTOTYPES 
 
-bool validSection(int section);
+bool validSection(std::string section);
 
 
 #endif // __CONSTANTS_H__

--- a/main.cpp
+++ b/main.cpp
@@ -856,8 +856,6 @@ void processcustomizationfile(std::vector<Student*> &students) {
     // create sections
     int counter = 0;
     for (nlohmann::json::iterator itr2 = (itr.value()).begin(); itr2 != (itr.value()).end(); itr2++) {
-    /*std::string temp = itr2.key();
-    int section = std::stoi(temp);*/
     std::string section = itr2.key();
     std::string section_name = itr2.value();
     std::cout << "MAKE ASSOCIATION " << section << " " << section_name << std::endl;

--- a/output.cpp
+++ b/output.cpp
@@ -256,7 +256,7 @@ void colorit_major(std::ostream &ostr, const std::string& s) {
 
 
 void colorit_section(std::ostream &ostr,
-                     int section, bool for_instructor, const std::string &color) {
+                     std::string section, bool for_instructor, const std::string &color) {
 
   std::string section_name;
 
@@ -264,18 +264,18 @@ void colorit_section(std::ostream &ostr,
     section_name = sectionNames[section];
   std::string section_color = sectionColors[section_name];
 
-  if (section == 0) {
+  if (section == "null") {
     section_color=color;
   }
 
   if (for_instructor) {
-    if (section != 0) {
+    if (section != "null") {
       ostr << "<td align=center bgcolor=" << section_color << ">" << section << "&nbsp;(" << section_name << ")</td>";
     } else {
       ostr << "<td align=center bgcolor=" << section_color << ">&nbsp;</td>" << std::endl;
     }
   } else {
-    if (section != 0) {
+    if (section != "null") {
       ostr << "<td align=center>" << section << "</td>";
     } else {
       ostr << "<td align=center bgcolor=" << section_color << ">&nbsp;</td>" << std::endl;
@@ -284,7 +284,7 @@ void colorit_section(std::ostream &ostr,
 
 }
 
-void colorit_section2(int section, std::string &color, std::string &label) {
+void colorit_section2(std::string section, std::string &color, std::string &label) {
   std::string section_name;
   if (validSection(section)) {
     section_name = sectionNames[section];
@@ -378,7 +378,7 @@ void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::
   std::string time = GLOBAL_EXAM_TIME;
   std::string row = "";
   std::string seat = "";
-  if (s->getSection() == 0) {
+  if (s->getSection() == "null") {
     //room = "";
     //zone = "";
     time = "";
@@ -698,7 +698,7 @@ void start_table_output( bool for_instructor,
 
   int myrank = 1;
   int myrow = 1;
-  int last_section = -1;
+  std::string last_section = "";
   for (unsigned int stu= 0; stu < students.size(); stu++) {
 
     Student *this_student = students[stu];
@@ -786,7 +786,7 @@ void start_table_output( bool for_instructor,
       std::string seat = "";
       std::string time = GLOBAL_EXAM_TIME;
 
-      if (this_student->getSection() == 0) { //LastName() == "") {
+      if (this_student->getSection() == "null") { //LastName() == "") {
         room = "";
         zone = "";
         time = "";

--- a/student.cpp
+++ b/student.cpp
@@ -13,7 +13,7 @@ Student::Student() {
   lefty = false;
   
   // registration status
-  section = 0;  
+  section = "null";  
   audit = false;
   withdraw = false;
   independentstudy = false;
@@ -268,7 +268,7 @@ float Student::lowest_test_counts_half_pct() const {
 // =============================================================================================
 
 int Student::getAllowedLateDays(int which_lecture) const {
-  if (getSection() == 0) return 0;
+  if (getSection() == "null") return 0;
   
   //int answer = 2;
 
@@ -321,7 +321,7 @@ float Student::overall_b4_moss() const {
 
 std::string Student::grade(bool flag_b4_moss, Student *lowest_d) const {
 
-  if (section == 0) return "";
+  if (section == "null") return "";
 
   if (!flag_b4_moss && manual_grade != "") return manual_grade;
   

--- a/student.h
+++ b/student.h
@@ -83,7 +83,7 @@ public:
   bool getLefty() const { return lefty; }
   
   // registration status
-  int getSection()           const { return section; }
+  const std::string& getSection()           const { return section; }
   bool getAudit()            const { return audit; }
   bool getWithdraw()         const { return withdraw; }
   bool getIndependentStudy() const { return independentstudy; }
@@ -133,7 +133,7 @@ public:
   void setLastUpdate(const std::string &s)    { lastUpdate = s; }
 
   // registration status
-  void setSection(int x) { section = x; }
+  void setSection(std::string x) { section = x; }
   void setAudit() { audit = true; }
   void setWithdraw() { withdraw = true; }
   void setIndependentStudy() { independentstudy = true; }
@@ -205,7 +205,7 @@ private:
   int default_allowed_late_days;
 
     // registration status
-  int section;
+  std::string section;
   bool audit;
   bool withdraw;
   bool independentstudy;

--- a/zone.cpp
+++ b/zone.cpp
@@ -430,7 +430,7 @@ void LoadExamSeatingFile(const std::string &zone_counts_filename,
       ostr_zone_assignments << std::setw(20) << std::left << l  << " ";
       ostr_zone_assignments << std::setw(15) << std::left << f << " ";
       ostr_zone_assignments << std::setw(12) << std::left << s->getUserName()  << " ";
-      if (s->getSection())
+      if (s->getSection() != "null")
         ostr_zone_assignments << std::setw(12) << std::left << s->getSection()  << " ";
       else
         ostr_zone_assignments << std::setw(12) << std::left << "" << " ";


### PR DESCRIPTION
This addresses [#2159](https://github.com/Submitty/Submitty/issues/2159) .

A couple observations:

1. As one of the comments notes, this will use lexicographical sorting. It would be nice if the user had some way to specify the sorting to use with `make section`, perhaps this should be made into an issue as a feature request? For example consider section names "ONE", "TWO", "THREE", or "1A", "1B", "2A", "2B". There's not going to be a good "one size fits all" rule for how those should be ordered - depends on the course and instructor preference.

2. Right now it looks like no test/lab grading is happening. This is not an issue with RainbowGrades, it's how the sample course is populated. I'm not sure if that's intentional or not - does lead to very sparse output when testing. I did some testing anyway, and I think what I've seen looks correct. 