### PR TITLE
Individual message improvements / migration to JSON

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -51,6 +51,13 @@ pull:
 push:
 	rsync -azP individual_summary_html/* ${USERNAME}@${HWSERVER}:${REPORTS_DIRECTORY}/summary_html/
 
+pull_test:
+	mkdir -p raw_data/
+	rsync -azPq ${REPORTS_DIRECTORY}/all_grades/ raw_data/
+
+push_test:
+	rsync -azPq individual_summary_html/* ${REPORTS_DIRECTORY}/summary_html/
+
 flags = -g
 memory_debug : memory_flags = -m32
 

--- a/gradeable.h
+++ b/gradeable.h
@@ -111,7 +111,9 @@ public:
     return released.find(id)->second;
   }
   float getItemMaximum(const std::string &id) const {
-    assert (maximums.find(id) != maximums.end());
+    if (maximums.find(id) == maximums.end()){
+      return 0;
+    }
     return maximums.find(id)->second;
   }
   float getScaleMaximum(const std::string &id) const {

--- a/main.cpp
+++ b/main.cpp
@@ -138,7 +138,8 @@ std::vector<std::string> MESSAGES;
 std::ofstream priority_stream("priority.txt");
 std::ofstream late_days_stream("late_days.txt");
 
-void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::json &special_message);
+//void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::json &special_message);
+void PrintExamRoomAndZoneTable(nlohmann::json &mj, Student *s, const nlohmann::json &special_message);
 
 //====================================================================
 
@@ -1539,17 +1540,17 @@ void output_helper(std::vector<Student*> &students,  std::string &GLOBAL_sort_or
 
     nlohmann::json mj;
 
-    std::string file2 = INDIVIDUAL_FILES_OUTPUT_DIRECTORY + students[S]->getUserName() + "_message.html";
+    //std::string file2 = INDIVIDUAL_FILES_OUTPUT_DIRECTORY + students[S]->getUserName() + "_message.html";
     std::string file2_json = INDIVIDUAL_FILES_OUTPUT_DIRECTORY + students[S]->getUserName() + "_message.json";
-    std::ofstream ostr2(file2.c_str());
+    //std::ofstream ostr2(file2.c_str());
     std::ofstream ostr2_json(file2_json.c_str());
 
-    mj["username"] = students[S]->getUserName();
+    /*mj["username"] = students[S]->getUserName();
     mj["building"] = "DCC";
     mj["room"] = "308";
     mj["zone"] = "A";
 
-    ostr2_json << mj.dump(4);
+    ostr2_json << mj.dump(4);*/
     
 
 #if 0
@@ -1575,7 +1576,10 @@ void output_helper(std::vector<Student*> &students,  std::string &GLOBAL_sort_or
       special_message = *special_message_itr;
     }
 
-    PrintExamRoomAndZoneTable(ostr2,students[S],special_message);
+    //PrintExamRoomAndZoneTable(ostr2,students[S],special_message);
+    PrintExamRoomAndZoneTable(mj,students[S],special_message);
+
+    ostr2_json << mj.dump(4);
 
     int prev = students[S]->getAllowedLateDays(0);
 

--- a/output.cpp
+++ b/output.cpp
@@ -326,13 +326,14 @@ void colorit(std::ostream &ostr,
 
 // ==========================================================
 
-void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::json &special_message) {
+//void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::json &special_message) {
+void PrintExamRoomAndZoneTable(nlohmann::json &mj, Student *s, const nlohmann::json &special_message) {
 
   if (special_message.size() > 0) {
     
-    ostr << "<table border=1 cellpadding=5 cellspacing=0 style=\"background-color:#ddffdd; width:auto;\">\n";
+    /*ostr << "<table border=1 cellpadding=5 cellspacing=0 style=\"background-color:#ddffdd; width:auto;\">\n";
     ostr << "<tr><td>\n";
-    ostr << "<table border=0 cellpadding=5 cellspacing=0>\n";
+    ostr << "<table border=0 cellpadding=5 cellspacing=0>\n";*/
 
     assert (special_message.find("title") != special_message.end());
     std::string title = special_message.value("title","MISSING TITLE");
@@ -340,7 +341,8 @@ void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::
     assert (special_message.find("description") != special_message.end());
     std::string description = special_message.value("description","provided_files.zip");
 
-    ostr << "<h3>" << title << "</h3>" << std::endl;
+    //ostr << "<h3>" << title << "</h3>" << std::endl;
+    mj["special_message"]["title"] = title;
 
     assert (special_message.find("files") != special_message.end());
     nlohmann::json files = *(special_message.find("files"));
@@ -362,10 +364,11 @@ void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::
     std::string filename = files.value(std::to_string(which),"");
     assert (filename != "");
 
-    ostr << "  <tr><td><a href=\"" << filename << "\" download=\"provided_files.zip\">" << description << "</a></td></tr>\n";
+    mj["special_message"]["filename"] = title;
+    /*ostr << "  <tr><td><a href=\"" << filename << "\" download=\"provided_files.zip\">" << description << "</a></td></tr>\n";
     ostr << "</table>\n";
     ostr << "</tr></td>\n";
-    ostr << "</table>\n";
+    ostr << "</table>\n";*/
   }
 
   // ==============================================================
@@ -401,7 +404,7 @@ void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::
 
 #if 1
 
-  ostr << "<table style=\"border:1px solid yellowgreen; background-color:#ddffdd; width:auto;\" >\n";
+  /*ostr << "<table style=\"border:1px solid yellowgreen; background-color:#ddffdd; width:auto;\" >\n";
   //  ostr << "<table border=\"1\" cellpadding=5 cellspacing=0 style=\"border:1px solid yellowgreen; background-color:#ddffdd;\">\n";
   ostr << "<tr><td>\n";
   ostr << "<table border=0 cellpadding=5 cellspacing=0>\n";
@@ -423,7 +426,26 @@ void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::
   }
 
 
-  ostr << "</table>\n";
+  ostr << "</table>\n";*/
+
+  mj["seating"]["title"] = GLOBAL_EXAM_TITLE;
+  mj["seating"]["date"] = GLOBAL_EXAM_DATE;
+  mj["seating"]["room"] = room;
+  mj["seating"]["zone"] = zone;
+  if (row != "N/A" && row !="") {
+    mj["seating"]["row"] = row;
+  }
+  if (seat != "N/A" && seat !="") {
+    mj["seating"]["seat"] = seat;
+  }
+
+  // It shouldn't be Rainbow Grades job to know that on the server it's zone_images/
+  // this should be done server side. Also allows server to let course specify hosting
+  // images on server or at a different location.
+  if (s->getExamZoneImage() != "") {
+    mj["seating"]["title"] = s->getExamZoneImage();
+  }
+
 
 #else
 

--- a/output.cpp
+++ b/output.cpp
@@ -329,6 +329,8 @@ void colorit(std::ostream &ostr,
 //void PrintExamRoomAndZoneTable(std::ofstream &ostr, Student *s, const nlohmann::json &special_message) {
 void PrintExamRoomAndZoneTable(nlohmann::json &mj, Student *s, const nlohmann::json &special_message) {
 
+  Student *s_tmp = s;
+
   if (special_message.size() > 0) {
     
     /*ostr << "<table border=1 cellpadding=5 cellspacing=0 style=\"background-color:#ddffdd; width:auto;\">\n";
@@ -364,15 +366,17 @@ void PrintExamRoomAndZoneTable(nlohmann::json &mj, Student *s, const nlohmann::j
     std::string filename = files.value(std::to_string(which),"");
     assert (filename != "");
 
-    mj["special_message"]["filename"] = title;
+    mj["special_message"]["filename"] = filename;
+    mj["special_message"]["description"] = description;
     /*ostr << "  <tr><td><a href=\"" << filename << "\" download=\"provided_files.zip\">" << description << "</a></td></tr>\n";
     ostr << "</table>\n";
     ostr << "</tr></td>\n";
     ostr << "</table>\n";*/
+
+    s = s_tmp; //Reset the student pointer in case exam seating needs it.
   }
 
   // ==============================================================
-
 
   if ( DISPLAY_EXAM_SEATING == false) return;
 

--- a/student.cpp
+++ b/student.cpp
@@ -129,6 +129,7 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
 
   // collect the scores in a vector
   std::vector<score_object> scores;
+  bool nonzero_gradeable = false;
   for (int i = 0; i < GRADEABLES[g].getCount(); i++) {
     float s = getGradeableItemGrade(g,i).getValue();
     std::string id = GRADEABLES[g].getID(i);
@@ -136,6 +137,14 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     float p = GRADEABLES[g].getItemPercentage(id);
     float sm = GRADEABLES[g].getScaleMaximum(id);
     scores.push_back(score_object(s,m,p,sm));
+    if (m > 0){
+      nonzero_gradeable = true;
+    }
+  }
+
+  //If there are no gradeables with a max >0, bucket is 0% anyway
+  if(!nonzero_gradeable){
+    return 0.0;
   }
 
   // sort the scores (smallest first)
@@ -160,7 +169,10 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     float sm = scores[i].scale_max;
     float my_max = std::max(m,sm);
     if (p < 0) {
-      assert (my_max > 0);
+      //Skip any non-contributing gradeable
+      if (my_max <= 0){
+        continue;
+      }
       if (sum_max > 0) {
         p = std::max(m,sm) / sum_max;
       } else {

--- a/student.cpp
+++ b/student.cpp
@@ -134,8 +134,11 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     float s = getGradeableItemGrade(g,i).getValue();
     std::string id = GRADEABLES[g].getID(i);
     if(!id.empty()){
-      nonzero_sum += GRADEABLES[g].getItemMaximum(id);
-      nonzero_count++;
+      float m = GRADEABLES[g].getItemMaximum(id);
+      if(m > 0){
+        nonzero_sum += m;
+        nonzero_count++;
+      }
     }    
   }
 
@@ -181,10 +184,6 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     float sm = scores[i].scale_max;
     float my_max = std::max(m,sm);
     if (p < 0) {
-      //Skip any non-contributing gradeable
-      /*if (my_max <= 0){
-        continue;
-      }*/
       assert(my_max > 0);
       if (sum_max > 0) {
         p = std::max(m,sm) / sum_max;


### PR DESCRIPTION
Closes Submitty/Submitty#1925

Half of the work for Submitty/Submitty#2279 and Submitty/Submitty#2280 as well, the rest of the work needs to be done in the main Submitty repo. Namely, the MakefileHelper now has a target which can be used by the test script, and the Rainbow-grades side behavior for count > defined gradeables is now correct.

The other half of the work is in Submitty/Submitty#2314