### PR TITLE
Assign Weights Sorted By Score ( "sorted_weights" )

### DIFF
--- a/gradeable.h
+++ b/gradeable.h
@@ -133,6 +133,15 @@ public:
     return clamps.find(id)->second;
   }
 
+  float getSortedWeight(unsigned int position){
+      assert(position < sorted_weights.size());
+      return sorted_weights[position];
+  }
+
+  bool hasSortedWeight(){
+      return !sorted_weights.empty();
+  }
+
   // MODIFIERS
   void setRemoveLowest(int r) { remove_lowest=r; }
 
@@ -188,6 +197,10 @@ public:
     autograde_replacement_percentages[id] = autograde_replacement_percentage;
   }
 
+  void addSortedWeight(float weight){
+      sorted_weights.push_back(weight);
+  }
+
 private:
 
   // REPRESENTATION
@@ -198,6 +211,7 @@ private:
   std::map<std::string,float> maximums;
   std::map<std::string,float> scale_maximums;
   std::map<std::string,float> item_percentages;
+  std::vector<float> sorted_weights;
   std::map<std::string,float> clamps;
   std::map<std::string,bool> released;
   std::map<std::string,std::string> original_ids;

--- a/gradeable.h
+++ b/gradeable.h
@@ -37,7 +37,7 @@ inline std::string gradeable_to_string(const GRADEABLE_ENUM &g) {
 
 inline std::string spacify(const std::string &s) {
   std::string tmp = "";
-  for (int i = 0; i < s.size(); i++) {
+  for (std::string::size_type i = 0; i < s.size(); i++) {
     tmp += std::string(1,s[i]) + " ";
   }
   return tmp;

--- a/main.cpp
+++ b/main.cpp
@@ -535,7 +535,7 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
         GRADEABLES[g].addSortedWeight(weight);
 
         if(k>0){
-          assert(prev_weight >= weight && "SORTED WEIGHTS MUST BE IN DECREASING ORDER");
+          assert(prev_weight <= weight && "SORTED WEIGHTS MUST BE IN INCREASING ORDER");
         }
       }
 
@@ -546,6 +546,7 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
     // Set remove lowest for gradeable
     int num = one_gradeable_type.value("remove_lowest", 0);
     assert (num == 0 || (num >= 0 && num < GRADEABLES[g].getCount()));
+    assert ((num == 0 || !GRADEABLES[g].hasSortedWeight()) && "CANNOT USE remove_lowest AND sorted_weights SIMULTANEOUSLY");
     GRADEABLES[g].setRemoveLowest(num);
     ALL_GRADEABLES.push_back(g);
   }

--- a/main.cpp
+++ b/main.cpp
@@ -518,9 +518,8 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
     if(itr != one_gradeable_type.end()){
       //Verify that we have as many weights as the count in the bucket
       nlohmann::json weight_array =  one_gradeable_type["sorted_weights"];
-      assert(weight_array.size() == count && "NUMBER OF SORTED WEIGHTS DOES NOT MATCH COUNT IN GRADEABLE TYPE");
+      assert(weight_array.size() == count && "NUMBER OF SORTED WEIGHTS DOES NOT MATCH COUNT IN GRADEABLE CATEGORY");
 
-      //TODO: Buster finish this!
       //Extract the array of weights
       float scaled_weights_sum = 0.0;
       float prev_weight;
@@ -540,13 +539,13 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
       }
 
       //Verify that weights sum to close to the bucket percentage
-      assert(fabs(scaled_weights_sum - gradeable_total_percent) < 0.001 && "SCALED WEIGHTS SHOULD SUM TO GRADEABLE TYPE TOTAL PERCENTAGE");
+      assert(fabs(scaled_weights_sum - gradeable_total_percent) < 0.001 && "SCALED WEIGHTS SHOULD SUM TO GRADEABLE CATEGORY TOTAL PERCENTAGE");
     }
 
     // Set remove lowest for gradeable
     int num = one_gradeable_type.value("remove_lowest", 0);
     assert (num == 0 || (num >= 0 && num < GRADEABLES[g].getCount()));
-    assert ((num == 0 || !GRADEABLES[g].hasSortedWeight()) && "CANNOT USE remove_lowest AND sorted_weights SIMULTANEOUSLY");
+    assert ((num == 0 || !GRADEABLES[g].hasSortedWeight()) && "CANNOT USE remove_lowest AND sorted_weights IN THE SAME GRADEABLE CATEGORY");
     GRADEABLES[g].setRemoveLowest(num);
     ALL_GRADEABLES.push_back(g);
   }
@@ -634,6 +633,7 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
         GRADEABLES[g].setScaleMaximum(token_key,scale_maximum);
       }
       if (grade_id.find("percent") != grade_id.end()) {
+        assert(!GRADEABLES[g].hasSortedWeight() && "GRADE CATEGORY HAS sorted_weights FIELD WHICH WOULD OVERRIDE GRADEABLE-SPECIFIC percent FIELD");
         float item_percentage = grade_id.value("percent",-1.0);
         assert (item_percentage >= 0 && item_percentage <= 1.0);
         GRADEABLES[g].setItemPercentage(token_key,item_percentage);

--- a/main.cpp
+++ b/main.cpp
@@ -512,7 +512,37 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
     GRADEABLES.insert(std::make_pair(g,answer));
     assert (GRADEABLES[g].getCount() >= 0);
     assert (GRADEABLES[g].getPercent() >= 0.0 && GRADEABLES[g].getPercent() <= 1.0);
-  
+
+    //SORTED WEIGHTS
+    itr = one_gradeable_type.find("sorted_weights");
+    if(itr != one_gradeable_type.end()){
+      //Verify that we have as many weights as the count in the bucket
+      nlohmann::json weight_array =  one_gradeable_type["sorted_weights"];
+      assert(weight_array.size() == count && "NUMBER OF SORTED WEIGHTS DOES NOT MATCH COUNT IN GRADEABLE TYPE");
+
+      //TODO: Buster finish this!
+      //Extract the array of weights
+      float scaled_weights_sum = 0.0;
+      float prev_weight;
+      float weight;
+      for(unsigned int k=0; k < weight_array.size(); k++){
+        if(k>0){
+          prev_weight = weight;
+        }
+        nlohmann::json sorted_weight = weight_array[k];
+        weight = sorted_weight.get<float>();
+        scaled_weights_sum += weight;
+        GRADEABLES[g].addSortedWeight(weight);
+
+        if(k>0){
+          assert(prev_weight >= weight && "SORTED WEIGHTS MUST BE IN DECREASING ORDER");
+        }
+      }
+
+      //Verify that weights sum to close to the bucket percentage
+      assert(fabs(scaled_weights_sum - gradeable_total_percent) < 0.001 && "SCALED WEIGHTS SHOULD SUM TO GRADEABLE TYPE TOTAL PERCENTAGE");
+    }
+
     // Set remove lowest for gradeable
     int num = one_gradeable_type.value("remove_lowest", 0);
     assert (num == 0 || (num >= 0 && num < GRADEABLES[g].getCount()));

--- a/student.cpp
+++ b/student.cpp
@@ -131,7 +131,7 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
   float nonzero_sum = 0;
   int nonzero_count = 0;
   for (int i = 0; i < GRADEABLES[g].getCount(); i++) {
-    float s = getGradeableItemGrade(g,i).getValue();
+    //float s = getGradeableItemGrade(g,i).getValue();
     std::string id = GRADEABLES[g].getID(i);
     if(!id.empty()){
       float m = std::max(GRADEABLES[g].getItemMaximum(id),GRADEABLES[g].getScaleMaximum(id));

--- a/student.cpp
+++ b/student.cpp
@@ -195,6 +195,9 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
       assert(my_max > 0);
       if (sum_max > 0) {
         p = std::max(m,sm) / sum_max;
+        if(GRADEABLES[g].hasSortedWeight()){
+          p = GRADEABLES[g].getSortedWeight(i);
+        }
       } else {
         // pure extra credit category
         p = std::max(m,sm) / sum_scaled_max;
@@ -203,7 +206,12 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     sum += p * s / my_max;
   }
 
-  return 100*GRADEABLES[g].getPercent()*sum;
+  if(GRADEABLES[g].hasSortedWeight()){
+      return 100*sum;
+  }
+  else {
+      return 100 * GRADEABLES[g].getPercent() * sum;
+  }
 }
 
 

--- a/zone.cpp
+++ b/zone.cpp
@@ -203,7 +203,7 @@ void LoadExamSeatingFile(const std::string &zone_counts_filename,
           all_seats.push_back(seat);
         }
         bool skip = false;
-        for (int i = 0; i < all_seats.size(); i++) {
+        for (std::vector<std::string>::size_type i = 0; i < all_seats.size(); i++) {
           seat = all_seats[i];
           //std::cout << "SEAT " << seat << std::endl;
           if (seat.back() == 'X') {


### PR DESCRIPTION
* Adds new functionality to Rainbow Grades, where the "sorted_weights" field can be added to one or more gradeable categories. Documentation still required.
* Cleaned up various compiler warnings. Was overzealous and used `std::string::size_type` and `std::vector<T>::size_type` where applicable, but we could use `unsigned int` instead and probably be fine.

Documentation:
Any gradeable category can have "sorted_weights" which maps to an array. The array must have as many entries as the "count", and these entries must be monotonically increasing. Each entry is a percent of the **overall** grade, where the right most entry is the percent that will be assigned to the best scoring assignment for a student in that gradeable category, and the leftmost is the percent that will be assigned to the worst scoring assignment. The sum of entries must match the "percent" of the gradeable category - in other words, in most cases these numbers will not sum to 1.00. Additionally, "remove_lowest" cannot be used in a category that is using "sorted_weights", instead one or more values in the "sorted_weights" array should be 0.0 to produce the same behavior.

Note: we are not removing "remove_lowest", because for cases where an instructor only wants a remove lowest behavior, it is much cleaner to use the existing syntax instead of "sorted_weights".