### PR TITLE
Test Improvement Averaging No Longer Improves 0s

### DIFF
--- a/iclicker.cpp
+++ b/iclicker.cpp
@@ -33,10 +33,11 @@ Date dateFromFilename(const std::string& filename_with_directory) {
     filename = filename.substr(pos+1,filename.size()-pos-1);
   }
 
-  assert (filename.size() == 15);
+  assert (filename.size() >= 15);
   assert (filename[0] == 'L');
   //  assert (filename[7] == '_');
-  assert (filename.substr(11,4) == ".csv");
+  //assert (filename.substr(11,4) == ".csv");
+  assert (filename.substr(filename.size()-4,4) == ".csv");
 
   Date answer;
 

--- a/student.cpp
+++ b/student.cpp
@@ -221,6 +221,7 @@ float Student::adjusted_test(int i) const {
   assert (i >= 0 && i <  GRADEABLES[GRADEABLE_ENUM::TEST].getCount());
   float a = getGradeableItemGrade(GRADEABLE_ENUM::TEST,i).getValue();
   float b;
+  if(a == 0) return a; //Don't allow students to improve on a missing test
   if (i+1 < GRADEABLES[GRADEABLE_ENUM::TEST].getCount()) {
     b = getGradeableItemGrade(GRADEABLE_ENUM::TEST,i+1).getValue();
   } else {

--- a/student.cpp
+++ b/student.cpp
@@ -221,7 +221,7 @@ float Student::adjusted_test(int i) const {
   assert (i >= 0 && i <  GRADEABLES[GRADEABLE_ENUM::TEST].getCount());
   float a = getGradeableItemGrade(GRADEABLE_ENUM::TEST,i).getValue();
   float b;
-  if(a == 0) return a; //Don't allow students to improve on a missing test
+  if (a == 0) return a; //Don't allow students to improve on a missing test
   if (i+1 < GRADEABLES[GRADEABLE_ENUM::TEST].getCount()) {
     b = getGradeableItemGrade(GRADEABLE_ENUM::TEST,i+1).getValue();
   } else {


### PR DESCRIPTION
It seems contrary to the spirit of test improvement averaging to take a missing test or a test with a 0 and measure anything as "improvement" that should overwrite the 0. Ideally at some point there would be a manual_grade_adjustment syntax if an instructor feels the need to adjust it.

More often than not, getting a 0 on a test (the method is hardcoded for `GRADEABLE_ENUM::TEST`) means the test was not taken. More careful instructor examination should be used in those cases instead of using the 0 as a measurement of real performance.

This PR will make the adjusted score of a test that had a raw value of 0 instead of (next test score)/2.