### PR TITLE
Overall Grade Failure By Category Cutoff

### DIFF
--- a/constants_and_globals.h
+++ b/constants_and_globals.h
@@ -45,7 +45,6 @@ extern int QUIZ_NORMALIZE_AND_DROP;
 extern std::map<std::string,std::string> sectionNames;
 extern std::map<std::string,std::string> sectionColors;
 
-
 extern std::map<std::string,float> CUTOFFS;
 extern std::map<Grade,int> grade_counts;
 extern std::map<Grade,float> grade_avg;

--- a/main.cpp
+++ b/main.cpp
@@ -63,6 +63,7 @@ std::vector<std::string> ICLICKER_QUESTION_NAMES;
 float MAX_ICLICKER_TOTAL;
 
 std::map<std::string,float> CUTOFFS;
+std::map<GRADEABLE_ENUM,float> OVERALL_FAIL_CUTOFFS;
 
 std::map<Grade,int> grade_counts;
 std::map<Grade,float> grade_avg;
@@ -549,6 +550,11 @@ void preprocesscustomizationfile(std::vector<Student*> &students) {
     assert ((num == 0 || !GRADEABLES[g].hasSortedWeight()) && "CANNOT USE remove_lowest AND sorted_weights IN THE SAME GRADEABLE CATEGORY");
     GRADEABLES[g].setRemoveLowest(num);
     ALL_GRADEABLES.push_back(g);
+
+    //Parse out the min grade required for passing in this category
+    float overall_cutoff = one_gradeable_type.value("overall_cutoff", 0.0);
+    assert(0.0 <= overall_cutoff && overall_cutoff <= 1.0);
+    OVERALL_FAIL_CUTOFFS.insert(std::make_pair(g,overall_cutoff));
   }
   
   // Set Benchmark Percent

--- a/student.cpp
+++ b/student.cpp
@@ -1,5 +1,6 @@
 #include "student.h"
 
+extern std::map<GRADEABLE_ENUM,float> OVERALL_FAIL_CUTOFFS;
 const std::string GradeColor(const std::string &grade);
 
 // =============================================================================================
@@ -371,9 +372,11 @@ std::string Student::grade(bool flag_b4_moss, Student *lowest_d) const {
   }
 
 
-  // some criteria that might indicate automatica failure of course
+  // some criteria that might indicate automatic failure of course
   // (instructor can override with manual grade)
-  int failed_lab   = (GradeablePercent(GRADEABLE_ENUM::LAB)       < 1.01 * lowest_d->GradeablePercent(GRADEABLE_ENUM::LAB)       ) ? true : false;
+
+  //Old (pre Su2019) DS method
+  /*int failed_lab   = (GradeablePercent(GRADEABLE_ENUM::LAB)       < 1.01 * lowest_d->GradeablePercent(GRADEABLE_ENUM::LAB)       ) ? true : false;
   int failed_hw    = (GradeablePercent(GRADEABLE_ENUM::HOMEWORK)  < 0.95 * lowest_d->GradeablePercent(GRADEABLE_ENUM::HOMEWORK)  ) ? true : false;
   int failed_testA = (GradeablePercent(GRADEABLE_ENUM::TEST)      < 0.90 * lowest_d->GradeablePercent(GRADEABLE_ENUM::TEST)      ) ? true : false;
   int failed_testB = (GradeablePercent(GRADEABLE_ENUM::EXAM)      < 0.90 * lowest_d->GradeablePercent(GRADEABLE_ENUM::EXAM)      ) ? true : false;
@@ -387,8 +390,19 @@ std::string Student::grade(bool flag_b4_moss, Student *lowest_d) const {
 
     //((Student*)this)->other_note += "SHOULD AUTO FAIL";
     return "F";
+  }*/
+
+
+
+  for(std::map<GRADEABLE_ENUM,float>::const_iterator it=OVERALL_FAIL_CUTOFFS.begin(); it != OVERALL_FAIL_CUTOFFS.end(); it++){
+      if(GradeablePercent(it->first)/100.0 < GRADEABLES[it->first].getPercent() * it->second){
+          /*std::cerr << "Failing student " << this->getUserName() << " due to low " << gradeable_to_string(it->first)
+                    << " grade of " << GradeablePercent(it->first)/100.0 << " < "
+                    << GRADEABLES[it->first].getPercent() * it->second << " max is "
+                    << GRADEABLES[it->first].getPercent() << std::endl;*/
+          return "F";
+      }
   }
-  
 
   // otherwise apply the cutoffs
   if (over >= CUTOFFS["A"])  return "A";


### PR DESCRIPTION
Closes Submitty/Submitty#3648

By adding `"overall_cutoff": percentage` where `percentage` is a number between 0.0 and 1.0 to a gradeable category, an instructor can now specify a minimum percentage of that category's points that must be earned by the student in order to not fail the course.

If no cutoff is provided for a given category, the cutoff is assumed to be 0.0 (no cutoff enforced).