### PR TITLE
Change MakefileHelper in preparation for automatic rainbow grades generation.

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -24,9 +24,6 @@ ifndef REPORTS_DIRECTORY
 $(error Variable REPORTS_DIRECTORY not set)
 endif
 
-#GRADING_DIRECTORY := $(RAINBOW_GRADES_DIRECTORY)/../grading
-
-
 nlohmann_json_dir=${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann/json
 
 ${nlohmann_json_dir}:
@@ -37,9 +34,6 @@ ${nlohmann_json_dir}:
 
 # Grab this file from the main Submitty repo
 json_syntax_checker.py = ${RAINBOW_GRADES_DIRECTORY}/../Submitty/grading/json_syntax_checker.py
-#${json_syntax_checker.py}:
-#	mkdir -p ${RAINBOW_GRADES_DIRECTORY}/../misc_tools/
-#	wget https://raw.githubusercontent.com/Submitty/Submitty/master/grading/json_syntax_checker.py -O ${json_syntax_checker.py}
 
 
 # =============================================================================

--- a/MakefileHelper
+++ b/MakefileHelper
@@ -24,7 +24,7 @@ ifndef REPORTS_DIRECTORY
 $(error Variable REPORTS_DIRECTORY not set)
 endif
 
-GRADING_DIRECTORY := $(RAINBOW_GRADES_DIRECTORY)/../grading
+#GRADING_DIRECTORY := $(RAINBOW_GRADES_DIRECTORY)/../grading
 
 
 nlohmann_json_dir=${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann/json
@@ -36,10 +36,10 @@ ${nlohmann_json_dir}:
 
 
 # Grab this file from the main Submitty repo
-json_syntax_checker.py = ${RAINBOW_GRADES_DIRECTORY}/../misc_tools/json_syntax_checker.py
-${json_syntax_checker.py}:
-	mkdir -p ${RAINBOW_GRADES_DIRECTORY}/../misc_tools/
-	wget https://raw.githubusercontent.com/Submitty/Submitty/master/grading/json_syntax_checker.py -O ${json_syntax_checker.py}
+json_syntax_checker.py = ${RAINBOW_GRADES_DIRECTORY}/../Submitty/grading/json_syntax_checker.py
+#${json_syntax_checker.py}:
+#	mkdir -p ${RAINBOW_GRADES_DIRECTORY}/../misc_tools/
+#	wget https://raw.githubusercontent.com/Submitty/Submitty/master/grading/json_syntax_checker.py -O ${json_syntax_checker.py}
 
 
 # =============================================================================


### PR DESCRIPTION
This PR makes a few small changes to the MakefileHelper file.  The path to json_syntax_checker.py now points to the copy that resides in the main submitty repo.  This change was necessary because the script that automatically generates rainbow grades may not have permission to clone files from the web, as is the previous setup.  Moving forward anyone who wishes to manually run rainbow grades must have the main submitty repo installed on their local machine along side the RainbowGrades repo.