### PR TITLE
Add Automatic Generation of All Students CSV

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -87,10 +87,10 @@ process_grades.out: \
 	${RAINBOW_GRADES_DIRECTORY}/benchmark.cpp
 	g++ -Wall ${flags} ${memory_flags} ${json_include} $^ -g -o $@
 
-individual_summary_html all_students_summary_html:
+individual_summary_html all_students_summary_csv all_students_summary_html:
 	mkdir -p $@
 
-compile: remove_json_comments process_grades.out individual_summary_html all_students_summary_html
+compile: remove_json_comments process_grades.out individual_summary_html all_students_summary_html all_students_summary_csv
 
 clean:
 	rm -rf *~ *.dSYM

--- a/main.cpp
+++ b/main.cpp
@@ -37,6 +37,7 @@ std::vector<std::string> OMIT_SECTION_FROM_STATS;
 
 std::string ICLICKER_ROSTER_FILE              = "./iclicker_Roster.txt";
 std::string OUTPUT_FILE                       = "./output.html";
+std::string OUTPUT_CSV_FILE                   = "./output.csv";
 std::string CUSTOMIZATION_FILE                = "./customization_no_comments.json";
 
 std::string RAW_DATA_DIRECTORY                = "./raw_data/";
@@ -1556,7 +1557,7 @@ void start_table_open_file(bool full_details,
 
 void start_table_output(bool full_details,
                         const std::vector<Student*> &students, int S, int month, int day, int year,
-                        Student *sp, Student *sa, Student *sb, Student *sc, Student *sd);
+                        Student *sp, Student *sa, Student *sb, Student *sc, Student *sd, bool csv_mode);
 
 void end_table(std::ofstream &ostr,  bool full_details, Student *s);
 
@@ -1598,7 +1599,10 @@ void output_helper(std::vector<Student*> &students,  std::string &GLOBAL_sort_or
   int year = now2->tm_year+1900;
 
   start_table_open_file(true,students,-1,month,day,year,GRADEABLE_ENUM::NONE);
-  start_table_output(true,students,-1,month,day,year, sp,sa,sb,sc,sd);
+  start_table_output(true,students,-1,month,day,year, sp,sa,sb,sc,sd,false);
+
+    start_table_open_file(true,students,-1,month,day,year,GRADEABLE_ENUM::NONE);
+    start_table_output(true,students,-1,month,day,year, sp,sa,sb,sc,sd,true);
 
   int next_rank = 1;
   //int last_section = -1;

--- a/main.cpp
+++ b/main.cpp
@@ -43,6 +43,7 @@ std::string CUSTOMIZATION_FILE                = "./customization_no_comments.jso
 std::string RAW_DATA_DIRECTORY                = "./raw_data/";
 std::string INDIVIDUAL_FILES_OUTPUT_DIRECTORY = "./individual_summary_html/";
 std::string ALL_STUDENTS_OUTPUT_DIRECTORY     = "./all_students_summary_html/";
+std::string ALL_STUDENTS_OUTPUT_DIRECTORY_CSV     = "./all_students_summary_csv/";
 
 nlohmann::json GLOBAL_CUSTOMIZATION_JSON;
 

--- a/output.cpp
+++ b/output.cpp
@@ -26,6 +26,7 @@
 extern std::string OUTPUT_FILE;
 extern std::string OUTPUT_CSV_FILE;
 extern std::string ALL_STUDENTS_OUTPUT_DIRECTORY;
+extern std::string ALL_STUDENTS_OUTPUT_DIRECTORY_CSV;
 
 extern Student* AVERAGE_STUDENT_POINTER;
 extern Student* STDDEV_STUDENT_POINTER;
@@ -1089,34 +1090,40 @@ void start_table_output( bool for_instructor,
     all_students.push_back(i);
   }
 
-  //TODO: Refactor since now we pass in csv_mode, the only part that needs the if statement is the WRITE ALL.xxx
   if(!csv_mode) {
       std::cout << "WRITE ALL.html" << std::endl;
-      std::ofstream ostr2(OUTPUT_FILE);
+      std::ofstream ostr_html(OUTPUT_FILE);
 
       GLOBAL_instructor_output = true;
-      table.output(ostr2, all_students, instructor_data, csv_mode);
+      table.output(ostr_html, all_students, instructor_data, csv_mode);
 
-      end_table(ostr2, true, NULL);
-      ostr2.close();
+      end_table(ostr_html, true, NULL);
+      ostr_html.close();
   }
   else {
       std::cout << "WRITE ALL.csv" << std::endl;
-      std::ofstream ostr2(OUTPUT_CSV_FILE);
+      std::ofstream ostr_csv(OUTPUT_CSV_FILE);
 
       GLOBAL_instructor_output = true;
-      table.output(ostr2, all_students, instructor_data, csv_mode);
+      table.output(ostr_csv, all_students, instructor_data, csv_mode);
 
-      //end_table(ostr2, true, NULL);
-      ostr2.close();
+      ostr_csv.close();
   }
 
   std::stringstream ss;
-  ss << ALL_STUDENTS_OUTPUT_DIRECTORY << "output_" << month << "_" << day << "_" << year << ".html";
-   
-  std::string command = "cp -f output.html " + ss.str();
-  std::cout << "RUN COMMAND " << command << std::endl;
-  system(command.c_str());
+
+  if(!csv_mode) {
+      ss << ALL_STUDENTS_OUTPUT_DIRECTORY << "output_" << month << "_" << day << "_" << year << ".html";
+      std::string command = "cp -f output.html " + ss.str();
+      std::cout << "RUN COMMAND " << command << std::endl;
+      system(command.c_str());
+  }
+  else{
+      ss << ALL_STUDENTS_OUTPUT_DIRECTORY_CSV << "output_" << month << "_" << day << "_" << year << ".csv";
+      std::string command = "cp -f output.csv " + ss.str();
+      std::cout << "RUN COMMAND " << command << std::endl;
+      system(command.c_str());
+  }
   
 
   for (std::map<int,std::string>::iterator itr = student_correspondences.begin();

--- a/output.cpp
+++ b/output.cpp
@@ -780,7 +780,7 @@ void start_table_output( bool for_instructor,
                   "<font color=\"00bb00\">" + recommendation + "</font>";
       }
       else{
-          THING = notes + "," + other_note + "," + recommendation;
+          THING = notes + " " + other_note + " " + recommendation;
       }
       assert (default_color.size()==6);
       table.set(myrow,counter++,TableCell(default_color,THING));

--- a/table.cpp
+++ b/table.cpp
@@ -8,6 +8,24 @@ bool GLOBAL_instructor_output = false;
 
 bool global_details = false;
 
+// XXX: For now not sanitizing \ since RFC4180 only specifies double quote as an escape
+//      i.e. """ is a field with one double quote as the value.
+//      In practice many other escape techniques are used, but we'll see how far this gets us
+//      and we can always add the \ into the sanitization list if users want it.
+//      Also ' is not part of RFC4180 so not stripping those for now either. Probably going
+//      to result in some strange behavior in some spreadsheet apps, need user testing.
+//      We could relax the stripping, allow commas, and ensure all output uses double quotes
+//      to wrap all fields. However, this would make using a text editor to read/edit the CSV painful.
+bool CSVSanitizeHelper(const char c){
+    return c == '"' || c == ',' || c == '\n' || c == '\r';
+}
+
+std::string CSVSanitizeString(const std::string& s){
+    std::string ret(s);
+    ret.erase(std::remove_if(ret.begin(), ret.end(), CSVSanitizeHelper), ret.end());
+    return ret;
+}
+
 TableCell::TableCell(const std::string& c, const std::string& d, const std::string& n, int ldu,
                      CELL_CONTENTS_STATUS v, const std::string& a, int s, int r) { 
   assert (c.size() == 6);
@@ -115,7 +133,7 @@ std::string TableCell::make_cell_string() const{
             std::cerr << "Printing note: " << mynote << std::endl;
         }
     }
-    return ret;
+    return CSVSanitizeString(ret);
 }
 
 

--- a/table.h
+++ b/table.h
@@ -18,6 +18,7 @@ public:
             CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& a="left" , int s=1, int r=0);
   TableCell(const std::string& c         , float              d   , int precision, const std::string& n="", int ldu=0,
             CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& a="right", int s=1, int r=0);
+  std::string make_cell_string() const;
 
   std::string color;
   std::string data;
@@ -57,6 +58,7 @@ public:
   void output(std::ostream& ostr,
               std::vector<int> which_students,
               std::vector<int> which_data,
+              bool csv_mode=false,
               bool transpose=false,
               bool show_details=false,
               std::string last_update="") const;

--- a/table.h
+++ b/table.h
@@ -3,10 +3,15 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
 
 extern bool GLOBAL_instructor_output;
 
 enum CELL_CONTENTS_STATUS { CELL_CONTENTS_VISIBLE, CELL_CONTENTS_HIDDEN, CELL_CONTENTS_VISIBLE_STUDENT, CELL_CONTENTS_VISIBLE_INSTRUCTOR, CELL_CONTENTS_NO_DETAILS };
+
+//Helper function for sanitization
+bool CSVSanitizeHelper(const char c);
+std::string CSVSanitizeString(const std::string& s);
 
 class TableCell {
 public:


### PR DESCRIPTION
Closes Submitty/Submitty#2659

This PR adds the capability to Rainbow Grades to generate both an output.html and output.csv for the instructor. In addition, the generation is always turned on and does not require any changes to `customization.json`.

The CSV sanitization is done based on rules set forth in RFC4180. While we could relax these rules and wrap each cell's contents in double quotes, this PR favors the simplest approach and keeping the generated CSV size down (currently a test set that created a 14MB output.html creates a 291KB output.csv). Further changes may be warranted depending on user reports and CSV behavior across the different programs that users might use to view the generated `output.csv`

Testing was done with exam seating, participation, understanding, instructor notes, moss, final grades, and iclickers.