### PR TITLE
[Bugfix] names not ignoring case when sorting

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -210,12 +210,17 @@ private:
 
 // FOR OTHER THINGS
 
+std::string lowerCase(std::string str) {
+   for(unsigned int i=0;i<str.length();i++){
+      str[i] = std::tolower(str[i]);
+   }
+   return str;
+}
 
 bool by_name(const Student* s1, const Student* s2) {
-  return (s1->getLastName() < s2->getLastName() ||
-          (s1->getLastName() == s2->getLastName() &&
-           s1->getFirstName() < s2->getFirstName()));
-  // should sort by legal name presumably (for data entry)
+  return (lowerCase(s1->getPreferredLastName()) < lowerCase(s2->getPreferredLastName()) ||
+          (lowerCase(s1->getPreferredLastName()) == lowerCase(s2->getPreferredLastName()) &&
+           lowerCase(s1->getPreferredFirstName()) < lowerCase(s2->getPreferredFirstName())));
 }
 
 std::string padifonlydigits(const std::string& s, unsigned int n) {


### PR DESCRIPTION
closes https://github.com/Submitty/Submitty/issues/4589
When sorting names the case of the name was not ignored, so something like Zebra vanRensselaer would put Zebra first instead of second.

This issue involved 2 problems, the first was what I said above, it was not ignoring the case of the letters. However the second issue was that it was using the legal name and not the preferred name even though (at least in the way I was testing output) it was outputting the preferred name.

In the comments for the function was this `// should sort by legal name presumably (for data entry)`, I have no idea what this means, but it was put there for a reason. Git blame says @bmcutler was the person who added the comment in 2018 so maybe she can decide if there is a good reason to have it sort by legal name vs preferred name.