### PR TITLE
Add option to allow instructors to clamp maximum percentage score

### DIFF
--- a/gradeable.h
+++ b/gradeable.h
@@ -65,6 +65,7 @@ public:
   // ACCESSORS
   int getCount() const { return count; }
   float getPercent() const { return percent; }
+  float getMaxScorePercentage() const { return this->max_score_percentage; }
   float getMaximum() const { 
     if (maximums.size() == 0) return 0;
     assert (maximums.size() > 0);
@@ -162,6 +163,12 @@ public:
     return index;
   }
 
+  // Set the max percentage that can be received for a gradeable type.
+  // If the value is less than 0, it should be ignored.
+  void setMaxScorePercentage(float max_score_percentage) {
+    this->max_score_percentage = max_score_percentage;
+  }
+
   void setCorrespondenceName(const std::string& id, const std::string& name) {
     assert (hasCorrespondence(id));
     assert (correspondences[id].second == "");
@@ -215,6 +222,7 @@ private:
   int count;
   float percent;
   int remove_lowest;
+  float max_score_percentage;
   std::map<std::string,std::pair<int,std::string> > correspondences;
   std::map<std::string,float> maximums;
   std::map<std::string,float> scale_maximums;

--- a/gradeable.h
+++ b/gradeable.h
@@ -65,7 +65,7 @@ public:
   // ACCESSORS
   int getCount() const { return count; }
   float getPercent() const { return percent; }
-  float getMaxScorePercentage() const { return this->max_score_percentage; }
+  float getBucketPercentageUpperClamp() const { return this->bucket_percentage_upper_clamp; }
   float getMaximum() const { 
     if (maximums.size() == 0) return 0;
     assert (maximums.size() > 0);
@@ -165,8 +165,8 @@ public:
 
   // Set the max percentage that can be received for a gradeable type.
   // If the value is less than 0, it should be ignored.
-  void setMaxScorePercentage(float max_score_percentage) {
-    this->max_score_percentage = max_score_percentage;
+  void setBucketPercentageUpperClamp(float bucket_percentage_upper_clamp) {
+    this->bucket_percentage_upper_clamp = bucket_percentage_upper_clamp;
   }
 
   void setCorrespondenceName(const std::string& id, const std::string& name) {
@@ -222,7 +222,7 @@ private:
   int count;
   float percent;
   int remove_lowest;
-  float max_score_percentage;
+  float bucket_percentage_upper_clamp;
   std::map<std::string,std::pair<int,std::string> > correspondences;
   std::map<std::string,float> maximums;
   std::map<std::string,float> scale_maximums;

--- a/main.cpp
+++ b/main.cpp
@@ -554,6 +554,16 @@ void preprocesscustomizationfile(const std::string &now_string,
     GRADEABLES[g].setRemoveLowest(num);
     ALL_GRADEABLES.push_back(g);
 
+    // Used to clamp extra credit. For example, if there are 3 gradeables of a category, each worth 1/2
+    // percentage of a total score, a student could earn 1.5x the value for the gradeable category.
+    // We can clamp that by setting max_score_percentage to a value less than 1.5.
+    nlohmann::json::iterator max_percent_itr = one_gradeable_type.find("max_score_percentage");
+    float max_score_percentage = -1;
+    if (max_percent_itr != one_gradeable_type.end()){
+        max_score_percentage = max_percent_itr->get<float>();
+    }
+    GRADEABLES[g].setMaxScorePercentage(max_score_percentage);
+
     //Parse out the min grade required for passing in this category
     float overall_cutoff = one_gradeable_type.value("overall_cutoff", 0.0);
     assert(0.0 <= overall_cutoff && overall_cutoff <= 1.0);

--- a/main.cpp
+++ b/main.cpp
@@ -561,13 +561,13 @@ void preprocesscustomizationfile(const std::string &now_string,
 
     // Used to clamp extra credit. For example, if there are 3 gradeables of a category, each worth 1/2
     // percentage of a total score, a student could earn 1.5x the value for the gradeable category.
-    // We can clamp that by setting max_score_percentage to a value less than 1.5.
-    nlohmann::json::iterator max_percent_itr = one_gradeable_type.find("max_score_percentage");
-    float max_score_percentage = -1;
-    if (max_percent_itr != one_gradeable_type.end()){
-        max_score_percentage = max_percent_itr->get<float>();
+    // We can clamp that by setting bucket_percentage_upper_clamp to a value less than 1.5.
+    nlohmann::json::iterator upper_clamp_itr = one_gradeable_type.find("bucket_percentage_upper_clamp");
+    float bucket_percentage_upper_clamp = -1;
+    if (upper_clamp_itr != one_gradeable_type.end()){
+        bucket_percentage_upper_clamp = upper_clamp_itr->get<float>();
     }
-    GRADEABLES[g].setMaxScorePercentage(max_score_percentage);
+    GRADEABLES[g].setBucketPercentageUpperClamp(bucket_percentage_upper_clamp);
 
     //Parse out the min grade required for passing in this category
     float overall_cutoff = one_gradeable_type.value("overall_cutoff", 0.0);

--- a/student.cpp
+++ b/student.cpp
@@ -208,9 +208,9 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
   }
 
   float percentage = GRADEABLES[g].hasSortedWeight() ? sum : GRADEABLES[g].getPercent() * sum;
-  float max_score_percentage = GRADEABLES[g].getMaxScorePercentage();
-  if (max_score_percentage > 0) {
-    percentage = std::min(percentage, max_score_percentage);
+  float percentage_upper_clamp = GRADEABLES[g].getBucketPercentageUpperClamp();
+  if (percentage_upper_clamp > 0) {
+    percentage = std::min(percentage, percentage_upper_clamp);
   }
   return 100 * percentage;
 }

--- a/student.cpp
+++ b/student.cpp
@@ -207,17 +207,12 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     }
   }
 
-  if(GRADEABLES[g].hasSortedWeight()){
-      return 100*sum;
+  float percentage = GRADEABLES[g].hasSortedWeight() ? sum : GRADEABLES[g].getPercent() * sum;
+  float max_score_percentage = GRADEABLES[g].getMaxScorePercentage();
+  if (max_score_percentage > 0) {
+    percentage = std::min(percentage, max_score_percentage);
   }
-  else {
-      float percentage = GRADEABLES[g].getPercent() * sum;
-      float max_score_percentage = GRADEABLES[g].getMaxScorePercentage();
-      if (max_score_percentage > 0) {
-        percentage = std::min(percentage, max_score_percentage);
-      }
-      return 100 * percentage;
-  }
+  return 100 * percentage;
 }
 
 

--- a/student.cpp
+++ b/student.cpp
@@ -211,7 +211,12 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
       return 100*sum;
   }
   else {
-      return 100 * GRADEABLES[g].getPercent() * sum;
+      float percentage = GRADEABLES[g].getPercent() * sum;
+      float max_score_percentage = GRADEABLES[g].getMaxScorePercentage();
+      if (max_score_percentage > 0) {
+        percentage = std::min(percentage, max_score_percentage);
+      }
+      return 100 * percentage;
   }
 }
 


### PR DESCRIPTION
This PR adds a new option at the gradeable level of the customization json, ```max_score_percentage```. When set, ```max_score_percentage``` serves as a clamp/upper bound on the maximum possible percentage that a student can receive for a gradeable type.

An example use case:
Let lab gradeables be worth 10% of a student's score for the semester.
Let us have 3 labs, each of which is worth 5% of the total after extra credit (so students can skip one lab if they do all of the extra credit for the other two).
However, we only want at most 10% of a students grade to come from labs, not 15% in the case that they do all extra credit, so we set ```max_score_percentage``` to ```0.1``` (10%).

__Questions__
1. Clamping is done in the ```GradeablePercent``` function of ```student.cpp```, which appears to work. However, I am not well aquainted with testing rainbow grades to make sure that it doesn't need to be clamped elsewhere.
2. In the ```GradeablePercent``` function, there is a separate total percent computation that occurs of ```hasSortedWeight``` is true. What is ```hasSortedWeight``` and how should it interact with this extension?