### PR TITLE
[Refactor:RainbowGrades] Remove usage of json_syntax_checker.py

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -32,10 +32,6 @@ ${nlohmann_json_dir}:
 	unzip -o ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip -d ${nlohmann_json_dir}
 
 
-# Grab this file from the main Submitty repo
-json_syntax_checker.py = ${RAINBOW_GRADES_DIRECTORY}/../Submitty/grading/json_syntax_checker.py
-
-
 # =============================================================================
 
 pull:
@@ -73,7 +69,7 @@ json_include = -I${nlohmann_json_dir}/include/
 
 remove_json_comments: customization.json
 	cpp -xc++ $< | sed -e '/^#/d' > customization_no_comments.json
-	python3 ${json_syntax_checker.py} customization_no_comments.json
+	python3 -m json.tool customization_no_comments.json > /dev/null
 	grep '{"file":' customization_no_comments.json > iclicker_file_list.txt || true
 	python3 ${RAINBOW_GRADES_DIRECTORY}/parsexml.py iclicker_file_list.txt
 


### PR DESCRIPTION
This removes the link to mainline Submitty's json syntax checker and instead uses python's built-in [json.tool](https://docs.python.org/3/library/json.html#module-json.tool) module which does essentially the same thing as that script did when this line was added. We have not yet removed the line to deal with inline comments from the Makefile so that added capacity of `json_syntax_checker.py` is not yet used, but I believe the benefits of making this script standalone again is probably worth keeping those lines (especially given they are probably not going to be changed going forward (and have been fine for 3+ years already).