### PR TITLE
[Bugfix:RainbowGrades] "drop lowest" for different point values

### DIFF
--- a/student.cpp
+++ b/student.cpp
@@ -106,7 +106,17 @@ public:
 };
 
 bool operator<(const score_object &a, const score_object &b) {
-  return a.score < b.score;
+  float s1 = a.score;
+  float m1 = a.max;
+  float p1 = a.percentage;
+  float sm1 = a.scale_max;
+  float my_max1 = std::max(m1,sm1);
+  float s2 = b.score;
+  float m2 = b.max;
+  float p2 = b.percentage;
+  float sm2 = b.scale_max;
+  float my_max2 = std::max(m2,sm2);
+  return p1 * s1 / my_max1 < p2 * s2 / my_max2;
 }
 
 float Student::GradeablePercent(GRADEABLE_ENUM g) const {


### PR DESCRIPTION
operator< was changed to fix the drop lowest feature for gradeables with different point values.

More specifically, with the previous implementation of operator<, the lowest scores were dropped regardless of the max and the percentage. It was causing the lowest absolute values of scores to always be dropped. E.g., among five scores 8/8, 8/8, 10/12, 15/30, 12/50, it would select 8/8, 8/8, and 10/12 to drop although these are the highest scores in this list if max is taken into account.

With the new implementation, this problem is fixed and the correct gradeables with the lowest scores are selected to be dropped. Following the example above, it would be 10/12, 15/30, and 12/50 for drop the lowest three.