### PR TITLE
[Bugfix:TAGrading] floating point for gradable perfect

### DIFF
--- a/gradeable.h
+++ b/gradeable.h
@@ -69,7 +69,7 @@ public:
   float getMaximum() const { 
     if (maximums.size() == 0) return 0;
     assert (maximums.size() > 0);
-    int max_sum = 0;
+    float max_sum = 0;
     for (std::map<std::string,float>::const_iterator itr = maximums.begin();
          itr != maximums.end(); itr++) {
       max_sum += itr->second;

--- a/main.cpp
+++ b/main.cpp
@@ -663,11 +663,11 @@ void preprocesscustomizationfile(const std::string &now_string,
         GRADEABLES[g].setReleased(token_key,released);
       }
 
-      float maximum = grade_id.value("max",0);
+      float maximum = grade_id.value("max",0.0);
       GRADEABLES[g].setMaximum(token_key,maximum);
 
       if (grade_id.find("scale_max") != grade_id.end()) {
-        float scale_maximum = grade_id.value("scale_max",0);
+        float scale_maximum = grade_id.value("scale_max",0.0);
         assert (scale_maximum > 0);
         GRADEABLES[g].setScaleMaximum(token_key,scale_maximum);
       }

--- a/submini_polls.cpp
+++ b/submini_polls.cpp
@@ -143,7 +143,7 @@ void LoadPolls(const std::vector<Student*> &students) {
   
   for (std::map<std::string,std::map<int,Poll> >::iterator it = GLOBAL_lectures.begin(); it != GLOBAL_lectures.end(); it++) {
     for (std::map<int,Poll>::iterator it2 = it->second.begin(); it2 != it->second.end(); it2++) {
-      std::cout << "print it " << it2->second << std::endl;
+      //std::cout << "print it " << it2->second << std::endl;
     }
   }
 }


### PR DESCRIPTION
Previously the gradeable maximum was assumed to be an integer.  Now we correctly handle floating point values.