### PR TITLE
[Refactor:RainbowGrades] Edit Moss Default Value

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -946,7 +946,7 @@ void start_table_output( bool /*for_instructor*/,
     if (DISPLAY_FINAL_GRADE) {
       std::string g = this_student->grade(false,sd);      
       color = GradeColor(g);
-      if (this_student->getMossPenalty() < -0.01) {
+      if (this_student->getMossPenalty() < -0.00000001) {
         g += "@";
       }
       assert (color.size()==6);
@@ -1174,8 +1174,15 @@ void start_table_output( bool /*for_instructor*/,
 void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
 
   ostr << "<p>* = 1 late day used</p>" << std::endl;
-  // This should only pop up for those who violated policy FIX HERE
-  // ostr << "<p>@ = Academic Integrity Violation</p>" << std::endl;
+
+  bool print_moss_message = false;
+  if (s != NULL && s->getMossPenalty() < -0.0000001) {
+    print_moss_message = true;
+  }
+
+  if (print_moss_message) {
+    ostr << "@ = Academic Integrity Violation penalty<p>&nbsp;<p>\n";
+  }
 
   if (s != NULL) {
     std::ifstream istr("student_poll_reports/"+s->getUserName()+".html");
@@ -1188,14 +1195,6 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
   }
   ostr << "<p>&nbsp;<p>\n";
 
-  bool print_moss_message = false;
-  if (s != NULL && s->getMossPenalty() < -0.01) {
-    print_moss_message = true;
-  }
-
-  if (print_moss_message) {
-    ostr << "@ = final grade with Academic Integrity Violation penalty<p>&nbsp;<p>\n";
-  }
 
   if (DISPLAY_FINAL_GRADE) { // && students.size() > 50) {
 

--- a/student.cpp
+++ b/student.cpp
@@ -488,7 +488,7 @@ void Student::mossify(const std::string &gradeable, float penalty) {
   // but it will be multiplied by a negative and added to the total;
   assert (penalty >= 0);
 
-  moss_penalty += -0.0000001;
+  moss_penalty += -0.0000002;
   moss_penalty += -average_letter_grade * penalty;
   std::stringstream foo;
   foo << std::setprecision(2) << std::fixed << penalty;


### PR DESCRIPTION
The current mossify function assumes average_letter_grade to be greater than 0. 
moss_penalty += -average_letter_grade * penalty;
s->getMossPenalty() < -0.01 is the threshold to check if student has moss penalty.
However, if value of average_letter_grade or penalty is 0, it does not pass the threshold and does not catch the student when displaying the black outline or adding @ to final grade.

Hence, quick fix made by increasing the default moss_penalty from
-0.0000001 -> -0.0000002 