### PR TITLE
[Feature:RainbowGrades] Display only applied border

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1074,6 +1074,7 @@ void processcustomizationfile(const std::string &now_string,
       //std::cout << "USERNAME " << username << std::endl;
       assert (s != NULL);
       s->mossify(hw,penalty);
+      s->set_event_academic_integrity(true);
     }
   } else if (token == "final_cutoff") {
     for (nlohmann::json::iterator itr2 = (itr.value()).begin(); itr2 != (itr.value()).end(); itr2++) {
@@ -1355,24 +1356,23 @@ void load_student_grades(std::vector<Student*> &students) {
                         if (status.find("Bad") != std::string::npos) {
                           assert (late_days_charged == 0);
                         }
-
-                        std::string event;
-                        std::string status_check = itr2->value("status", "");
-                        if (status_check == "Bad")
-                        {
-                          event = "Bad";
-                        }
-                        if (status_check == "Overridden")
-                        {
-                          event = "Overridden";
-                        }
-                        std::string inquiry = itr2->value("inquiry", "");
-                        if ((inquiry != "None") && (inquiry != "Resolved") && (inquiry != ""))
-                        {
-                          assert(inquiry == "Open");
-                          event = "Open";
-                        }
                         if (GRADEABLES[g].isReleased(gradeable_id)) {
+                           std::string event;
+                           std::string status_check = itr2->value("status", "");
+                           if (status_check == "Bad") {
+                             event = "Bad";
+                             s->set_event_bad_status(true);
+                           }
+                           if (status_check == "Overridden") {
+                             event = "Overridden";
+                             s->set_event_overridden(true);
+                           }
+                           std::string inquiry = itr2->value("inquiry", "");
+                           if ((inquiry != "None") && (inquiry != "Resolved") && (inquiry != "")) {
+                             assert(inquiry == "Open");
+                             event = "Open";
+                             s->set_event_grade_inquiry(true);
+                           }
                           s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);
                         }
       }

--- a/output.cpp
+++ b/output.cpp
@@ -1174,8 +1174,64 @@ void start_table_output( bool /*for_instructor*/,
 void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
 
   ostr << "<p>* = 1 late day used</p>" << std::endl;
-  // This should only pop up for those who violated policy FIX HERE
-  // ostr << "<p>@ = Academic Integrity Violation</p>" << std::endl;
+
+  // Description of border outline that are in effect
+  if (s != NULL)
+  {
+      if (s->get_event_bad_status() || s->get_event_grade_inquiry() || s->get_event_overridden() || s->get_event_academic_integrity())
+      {
+        ostr << "<style> .spacer {display: inline-block; width: 66px;} </style>\n";
+        ostr << "<table style=\"border:1px solid #aaaaaa; background-color:#FFFFFF;\">\n";
+        if (s->get_event_academic_integrity())
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px solid #0a0a0a; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Academic Integrity Violation </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
+        if (s->get_event_overridden())
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px solid #fcca03; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Grade override </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
+        if (s->get_event_grade_inquiry())
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px dashed #1cfc03; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Grade inquiry in progress </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
+        if (s->get_event_bad_status())
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px solid #fc0303; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Bad status = too many late days used on this assignment <br> ";
+          ostr << "<span class=\"spacer\"></span> OR you didn’t have enough late days to use </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
+        ostr << "</table>\n";
+      }
+  }
+
+
 
   if (s != NULL) {
     std::ifstream istr("student_poll_reports/"+s->getUserName()+".html");

--- a/student.h
+++ b/student.h
@@ -178,6 +178,15 @@ public:
 
   void mossify(const std::string &gradeable, float penalty);
 
+    void set_event_academic_integrity(bool value) {academic_integrity = value;}
+    void set_event_grade_inquiry(bool value) {grade_inquiry = value;}
+    void set_event_overridden(bool value) {overridden = value;}
+    void set_event_bad_status(bool value) {bad_status = value;}
+    bool get_event_academic_integrity() {return academic_integrity;}
+    bool get_event_grade_inquiry() {return grade_inquiry;}
+    bool get_event_overridden() {return overridden;}
+    bool get_event_bad_status() {return bad_status;}
+
   // other grade-like data
   void setNumericID(const std::string& r_id) { numeric_id = r_id; }
   void setAcademicIntegrityForm() { academic_integrity_form = true; }
@@ -234,6 +243,10 @@ private:
 
   int current_allowed_late_days;
   int default_allowed_late_days;
+  bool academic_integrity = false;
+  bool grade_inquiry = false;
+  bool overridden = false;
+  bool bad_status = false;
 
     // registration status
   std::string section;


### PR DESCRIPTION
Currently the description of all border outline is on rainbowgrades.
Students who are not related, should not see phrase such as "academic integrity violation" anywhere in their rainbowgrades.
With this change, description that are only in effect of student's rainbowgrades will be visible. 

<img width="330" alt="Screen Shot 2023-08-22 at 9 58 46 AM" src="https://github.com/Submitty/RainbowGrades/assets/123261952/970b327d-85ed-46dc-a672-4b729500d66b">

<img width="345" alt="Screen Shot 2023-08-22 at 9 59 13 AM" src="https://github.com/Submitty/RainbowGrades/assets/123261952/3b09b617-e162-4425-a6f5-86f719949582">

<img width="359" alt="Screen Shot 2023-08-22 at 10 00 34 AM" src="https://github.com/Submitty/RainbowGrades/assets/123261952/b6a2950f-4896-45f0-8e33-ffc4ec991f84">
