### PR TITLE
[Refactor: RainbowGrades] Academic sanction

### DIFF
--- a/constants_and_globals.h
+++ b/constants_and_globals.h
@@ -11,7 +11,7 @@ class Student;
 // What sections to display in the output table
 extern bool DISPLAY_INSTRUCTOR_NOTES;
 extern bool DISPLAY_EXAM_SEATING;
-extern bool DISPLAY_MOSS_DETAILS;
+extern bool DISPLAY_ACADEMIC_SANCTION_DETAILS;
 extern bool DISPLAY_FINAL_GRADE;
 extern bool DISPLAY_GRADE_SUMMARY;
 extern bool DISPLAY_GRADE_DETAILS;

--- a/main.cpp
+++ b/main.cpp
@@ -124,7 +124,7 @@ std::string BONUS_FILE;
 
 bool DISPLAY_INSTRUCTOR_NOTES = false;
 bool DISPLAY_EXAM_SEATING = false;
-bool DISPLAY_MOSS_DETAILS = false;
+bool DISPLAY_ACADEMIC_SANCTION_DETAILS = false;
 bool DISPLAY_FINAL_GRADE = false;
 bool DISPLAY_GRADE_SUMMARY = false;
 bool DISPLAY_GRADE_DETAILS = false;
@@ -151,8 +151,8 @@ void PrintExamRoomAndZoneTable(const std::string &id, nlohmann::json &mj, Studen
 
 
 bool by_overall(const Student* s1, const Student* s2) {
-  float s1_overall = s1->overall_b4_moss();
-  float s2_overall = s2->overall_b4_moss();
+  float s1_overall = s1->overall_b4_academic_sanction();
+  float s2_overall = s2->overall_b4_academic_sanction();
 
   if (s1 == AVERAGE_STUDENT_POINTER) return true;
   if (s2 == AVERAGE_STUDENT_POINTER) return false;
@@ -373,8 +373,8 @@ void preprocesscustomizationfile(const std::string &now_string,
         DISPLAY_INSTRUCTOR_NOTES = true;
       } else if (token == "exam_seating") {
         DISPLAY_EXAM_SEATING = true;
-      } else if (token == "moss_details") {
-        DISPLAY_MOSS_DETAILS = true;
+      } else if (token == "academic_sanction_details") {
+        DISPLAY_ACADEMIC_SANCTION_DETAILS = true;
       } else if (token == "final_grade") {
         DISPLAY_FINAL_GRADE = true;
       } else if (token == "grade_summary") {
@@ -765,8 +765,8 @@ void preprocesscustomizationfile(const std::string &now_string,
       DISPLAY_INSTRUCTOR_NOTES = true;
     } else if (token == "exam_seating") {
       DISPLAY_EXAM_SEATING = true;
-    } else if (token == "moss_details") {
-      DISPLAY_MOSS_DETAILS = true;
+    } else if (token == "academic_sanction_details") {
+      DISPLAY_ACADEMIC_SANCTION_DETAILS = true;
     } else if (token == "final_grade") {
       DISPLAY_FINAL_GRADE = true;
     } else if (token == "grade_summary") {
@@ -1073,7 +1073,7 @@ void processcustomizationfile(const std::string &now_string,
       Student *s = GetStudent(students,username);
       //std::cout << "USERNAME " << username << std::endl;
       assert (s != NULL);
-      s->mossify(hw,penalty);
+      s->academic_sanction(hw,penalty);
       s->set_event_academic_integrity(true);
     }
   } else if (token == "final_cutoff") {
@@ -1765,7 +1765,7 @@ int main(int argc, char* argv[]) {
 
     DISPLAY_INSTRUCTOR_NOTES = false;
     DISPLAY_EXAM_SEATING = true;
-    DISPLAY_MOSS_DETAILS = false;
+    DISPLAY_ACADEMIC_SANCTION_DETAILS = false;
     DISPLAY_FINAL_GRADE = false;
     DISPLAY_GRADE_SUMMARY = false;
     DISPLAY_GRADE_DETAILS = false;

--- a/output.cpp
+++ b/output.cpp
@@ -607,7 +607,7 @@ void start_table_output( bool /*for_instructor*/,
     std::cout << "DISPLAY FINAL GRADE" << std::endl;
     student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","FINAL GRADE"));
     student_data.push_back(counter); table.set(0,counter++,TableCell(grey_divider));
-    if (DISPLAY_MOSS_DETAILS) {
+    if (DISPLAY_ACADEMIC_SANCTION_DETAILS) {
       table.set(0,counter++,TableCell("ffffff","RAW GRADE"));
       table.set(0,counter++,TableCell(grey_divider));
     }
@@ -946,14 +946,14 @@ void start_table_output( bool /*for_instructor*/,
     if (DISPLAY_FINAL_GRADE) {
       std::string g = this_student->grade(false,sd);      
       color = GradeColor(g);
-      if (this_student->getMossPenalty() < -0.00000001) {
+      if (this_student->getAcademicSanctionPenalty() < -0.00000001) {
         g += "@";
       }
       assert (color.size()==6);
       table.set(myrow,counter++,TableCell(color,g,"",0,CELL_CONTENTS_VISIBLE,"center"));
       table.set(myrow,counter++,TableCell(grey_divider));
 
-      if (DISPLAY_MOSS_DETAILS) {
+      if (DISPLAY_ACADEMIC_SANCTION_DETAILS) {
         std::string g2 = this_student->grade(true,sd);
         color = GradeColor(g2);
         table.set(myrow,counter++,TableCell(color,g2,"",0,CELL_CONTENTS_VISIBLE,"center"));
@@ -1176,12 +1176,12 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
   ostr << "<p>* = 1 late day used</p>" << std::endl;
 
 
-  bool print_moss_message = false;
-  if (s != NULL && s->getMossPenalty() < -0.0000001) {
-    print_moss_message = true;
+  bool print_academic_sanction_message = false;
+  if (s != NULL && s->getAcademicSanctionPenalty() < -0.0000001) {
+    print_academic_sanction_message = true;
   }
 
-  if (print_moss_message) {
+  if (print_academic_sanction_message) {
     ostr << "@ = Academic Integrity Violation penalty<p>&nbsp;<p>\n";
   }
 

--- a/student.cpp
+++ b/student.cpp
@@ -35,7 +35,7 @@ Student::Student() {
 
   rotating_section = -1;
   zones = std::vector<std::string>(GRADEABLES[GRADEABLE_ENUM::TEST].getCount(),"");
-  moss_penalty = 0;
+  academic_sanction_penalty = 0;
   cached_hw = -1;
 
   // other grade-like data
@@ -393,7 +393,7 @@ int Student::getUsedLateDays() const {
 
 // =============================================================================================
 
-float Student::overall_b4_moss() const {
+float Student::overall_b4_academic_sanction() const {
   float answer = 0;
   for (unsigned int i = 0; i < ALL_GRADEABLES.size(); i++) { 
     GRADEABLE_ENUM g = ALL_GRADEABLES[i];
@@ -402,15 +402,15 @@ float Student::overall_b4_moss() const {
   return answer;
 }
 
-std::string Student::grade(bool flag_b4_moss, Student *lowest_d) const {
+std::string Student::grade(bool flag_b4_academic_sanction, Student *lowest_d) const {
 
   if (section == "null") return "";
 
-  if (!flag_b4_moss && manual_grade != "") return manual_grade;
+  if (!flag_b4_academic_sanction && manual_grade != "") return manual_grade;
   
   float over = overall();
-  if (flag_b4_moss) {
-    over = overall_b4_moss();
+  if (flag_b4_academic_sanction) {
+    over = overall_b4_academic_sanction();
   }
 
 
@@ -465,7 +465,7 @@ std::string Student::grade(bool flag_b4_moss, Student *lowest_d) const {
 
 
 
-void Student::mossify(const std::string &gradeable, float penalty) {
+void Student::academic_sanction(const std::string &gradeable, float penalty) {
 
   // if the penalty is "a whole or partial letter grade"....
   float average_letter_grade = (CUTOFFS["A"]-CUTOFFS["B"] +
@@ -475,11 +475,11 @@ void Student::mossify(const std::string &gradeable, float penalty) {
   int item;
   LookupGradeable(gradeable,g,item);
   if (!GRADEABLES[g].hasCorrespondence(gradeable)) {
-    std::cerr << "WARNING -- NO GRADEABLE TO MOSSIFY" << std::endl;
+    std::cerr << "WARNING -- NO GRADEABLE TO ACADEMIC SANCTION" << std::endl;
   } else {
     int which = GRADEABLES[g].getCorrespondence(gradeable).first;
     if (!(getGradeableItemGrade(g,which).getValue() > 0)) {
-      std::cerr << "WARNING:  the grade for this " <<gradeable_to_string(g)<<" is already 0, moss penalty error?" << std::endl;
+      std::cerr << "WARNING:  the grade for this " <<gradeable_to_string(g)<<" is already 0, academic sanction penalty error?" << std::endl;
     }
       setGradeableItemGrade_AcademicIntegrity(g,which,0, true);
   }
@@ -488,8 +488,8 @@ void Student::mossify(const std::string &gradeable, float penalty) {
   // but it will be multiplied by a negative and added to the total;
   assert (penalty >= 0);
 
-  moss_penalty += -0.0000002;
-  moss_penalty += -average_letter_grade * penalty;
+  academic_sanction_penalty += -0.0000002;
+  academic_sanction_penalty += -average_letter_grade * penalty;
   std::stringstream foo;
   foo << std::setprecision(2) << std::fixed << penalty;
 
@@ -515,11 +515,11 @@ void Student::ManualGrade(const std::string &grade, const std::string &message) 
 }
 
 
-void Student::outputgrade(std::ostream &ostr,bool flag_b4_moss,Student *lowest_d) const {
-  std::string g = grade(flag_b4_moss,lowest_d);
+void Student::outputgrade(std::ostream &ostr,bool flag_b4_academic_sanction,Student *lowest_d) const {
+  std::string g = grade(flag_b4_academic_sanction,lowest_d);
   
   std::string color = GradeColor(g);
-  if (moss_penalty < -0.01) {
+  if (academic_sanction_penalty < -0.01) {
     ostr << "<td align=center bgcolor=" << color << ">" << g << " @</td>";
   } else {
     ostr << "<td align=center bgcolor=" << color << ">" << g << "</td>";

--- a/student.h
+++ b/student.h
@@ -176,7 +176,7 @@ public:
   void setGradeableItemGrade_AcademicIntegrity(GRADEABLE_ENUM g, int i, float value, bool academic_integrity, int late_days_used=0, const std::string &note="",const std::string &status="");
   void setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event="", int late_days_used=0, const std::string &note="",const std::string &status="");
 
-  void mossify(const std::string &gradeable, float penalty);
+  void academic_sanction(const std::string &gradeable, float penalty);
 
     void set_event_academic_integrity(bool value) {academic_integrity = value;}
     void set_event_grade_inquiry(bool value) {grade_inquiry = value;}

--- a/student.h
+++ b/student.h
@@ -108,7 +108,7 @@ public:
   int getPollsIncorrect() const;
   float getPollPoints() const;
   int getUsedLateDays() const;
-  float getMossPenalty() const { return moss_penalty; }
+  float getAcademicSanctionPenalty() const { return academic_sanction_penalty; }
 
   void setCurrentAllowedLateDays(int d) { current_allowed_late_days = d; }
   void setDefaultAllowedLateDays(int d) { default_allowed_late_days = d; }
@@ -217,14 +217,14 @@ public:
 
   // HELPER FUNCTIONS
   float GradeablePercent(GRADEABLE_ENUM g) const;
-  float overall() const { return overall_b4_moss() + moss_penalty; }
+  float overall() const { return overall_b4_academic_sanction() + academic_sanction_penalty; }
   float adjusted_test(int i) const;
   float adjusted_test_pct() const;
   float lowest_test_counts_half_pct() const;
   float quiz_normalize_and_drop(int num) const;
-  float overall_b4_moss() const;
-  std::string grade(bool flag_b4_moss, Student *lowest_d) const;
-  void outputgrade(std::ostream &ostr,bool flag_b4_moss,Student *lowest_d) const;
+  float overall_b4_academic_sanction() const;
+  std::string grade(bool flag_b4_academic_sanction, Student *lowest_d) const;
+  void outputgrade(std::ostream &ostr,bool flag_b4_academic_sanction,Student *lowest_d) const;
   
 private:
 
@@ -260,7 +260,7 @@ private:
   std::map<GRADEABLE_ENUM,std::vector<ItemGrade> > all_item_grades;
   
   std::vector<std::string> zones;
-  float moss_penalty;
+  float academic_sanction_penalty;
   float cached_hw;
   int rank;
 


### PR DESCRIPTION
Closes https://github.com/Submitty/Submitty/issues/9725
Changed all the mossify and moss instances to academic_sanction in three documents (main.cpp, student.cpp, student.h) in the Rainbow Grades directory. These changes were made to avoid potential copyright issues.  

<img width="888" alt="image" src="https://github.com/Submitty/RainbowGrades/assets/117528498/97c09e1b-5262-4d1a-8a23-b8993536580d">
