### PR TITLE
[Feature:RainbowGrades] Display Extensions in RainbowGrades

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1375,6 +1375,10 @@ void load_student_grades(std::vector<Student*> &students) {
                            }
                            int late_day_exceptions = itr2->value("late_day_exceptions",0);
                            std::string reason_for_exception = itr2->value("reason_for_exception","");
+                           if (late_day_exceptions > 0) {
+                             event = "Extension";
+                             s->set_event_extension(true);
+                           }
                            s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
                         }
       }

--- a/main.cpp
+++ b/main.cpp
@@ -1736,7 +1736,7 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
     std::ofstream student_ostr("student_extension_reports/"+username+".html");
     assert (student_ostr.good());
     if (gradeablesWithExtensions.size() == 0) {
-      return;
+      continue;
     }
     student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
     student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -1740,7 +1740,7 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
     }
     student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
     student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;
-    student_ostr << "<tr><td>Gradeable</td><td align=center> Days Extended </td><td align=center>Reason</td><td></td></tr>" << std::endl;
+    student_ostr << "<tr><td>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
     for (size_t i2=0;i2<gradeablesWithExtensions.size();i2++) {
       ItemGrade item = std::get<0>(gradeablesWithExtensions[i2]);
       GRADEABLE_ENUM g = std::get<0>(std::get<1>(gradeablesWithExtensions[i2]));

--- a/main.cpp
+++ b/main.cpp
@@ -1374,11 +1374,8 @@ void load_student_grades(std::vector<Student*> &students) {
                              s->set_event_grade_inquiry(true);
                            }
                            int late_day_exceptions = itr2->value("late_day_exceptions",0);
-                           if (late_day_exceptions > 0) {
-                             std::string reason_for_exception = itr2->value("reason_for_exception","");
-                             s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
-                           }
-                           else s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);
+                           std::string reason_for_exception = itr2->value("reason_for_exception","");
+                           s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
                         }
       }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1737,20 +1737,18 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
     student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
     student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;
     student_ostr << "<tr><td>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
-    else {
-      for (size_t i2=0;i2<gradeablesWithExtensions.size();i2++) {
-        ItemGrade item = std::get<0>(gradeablesWithExtensions[i2]);
-        GRADEABLE_ENUM g = std::get<0>(std::get<1>(gradeablesWithExtensions[i2]));
-        int index = std::get<1>(std::get<1>(gradeablesWithExtensions[i2]));
-        std::string gradeable_id = GRADEABLES[g].getID(index);
-        std::string gradeable_name = "";
-        if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
-          gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
-        }
-        student_ostr << "<tr><td>" << gradeable_name << "</td><td align=center>"
+    for (size_t i2=0;i2<gradeablesWithExtensions.size();i2++) {
+      ItemGrade item = std::get<0>(gradeablesWithExtensions[i2]);
+      GRADEABLE_ENUM g = std::get<0>(std::get<1>(gradeablesWithExtensions[i2]));
+      int index = std::get<1>(std::get<1>(gradeablesWithExtensions[i2]));
+      std::string gradeable_id = GRADEABLES[g].getID(index);
+      std::string gradeable_name = "";
+      if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
+        gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
+      }
+      student_ostr << "<tr><td>" << gradeable_name << "</td><td align=center>"
                    << item.getLateDayExceptions() << "</td><td align=center>"
                    << item.getReasonForException() << "</td></tr>" << std::endl;
-      }
     }
     student_ostr << "</table>" << std::endl;
   }

--- a/main.cpp
+++ b/main.cpp
@@ -1727,6 +1727,38 @@ void loadAllowedLateDays(std::vector<Student*> &students) {
   }
 }
 
+void SaveExtensionReports(const std::vector<Student*> &students) {
+  system ("mkdir -p student_extension_reports");
+  for (size_t i=0;i<students.size();i++) {
+    std::vector<std::tuple<ItemGrade,std::tuple<GRADEABLE_ENUM,int> > > gradeablesWithExtensions = students[i]->getItemsWithExceptions();
+    std::string username = students[i]->getUserName();
+    std::ofstream student_ostr("student_extension_reports/"+username+".html");
+    assert (student_ostr.good());
+    
+    student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
+    student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;
+    student_ostr << "<tr><td align=center>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
+    if (gradeablesWithExtensions.size() == 0) {
+      student_ostr << "<tr><td>N/a</td></tr>" << std::endl;
+    }
+    else {
+      for (size_t i2=0;i2<gradeablesWithExtensions.size();i2++) {
+        ItemGrade item = std::get<0>(gradeablesWithExtensions[i2]);
+        GRADEABLE_ENUM g = std::get<0>(std::get<1>(gradeablesWithExtensions[i2]));
+        int index = std::get<1>(std::get<1>(gradeablesWithExtensions[i2]));
+        std::string gradeable_id = GRADEABLES[g].getID(index);
+        std::string gradeable_name = "";
+        if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
+          gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
+        }
+        student_ostr << "<tr><td align=center>" << gradeable_name << "</td><td align=center>"
+                   << item.getLateDayExceptions() << "</td><td align=center>"
+                   << item.getReasonForException() << "</td></tr>" << std::endl;
+      }
+    }
+    student_ostr << "</table>" << std::endl;
+  }
+}
 
 int main(int argc, char* argv[]) {
 
@@ -1747,6 +1779,8 @@ int main(int argc, char* argv[]) {
 
   LoadPolls(students);
   SavePollReports(students);
+
+  SaveExtensionReports(students);
 
   loadAllowedLateDays(students);
 

--- a/main.cpp
+++ b/main.cpp
@@ -1374,11 +1374,11 @@ void load_student_grades(std::vector<Student*> &students) {
                              s->set_event_grade_inquiry(true);
                            }
                            int late_day_exceptions = itr2->value("late_day_exceptions",0);
-                          if (late_day_exceptions > 0) {
-                            std::string reason_for_exception = itr2->value("reason_for_exception","");
-                            s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
-                          }
-                          else s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);
+                           if (late_day_exceptions > 0) {
+                             std::string reason_for_exception = itr2->value("reason_for_exception","");
+                             s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
+                           }
+                           else s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);
                         }
       }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1731,13 +1731,12 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
     std::string username = students[i]->getUserName();
     std::ofstream student_ostr("student_extension_reports/"+username+".html");
     assert (student_ostr.good());
-    
+    if (gradeablesWithExtensions.size() == 0) {
+      return;
+    }
     student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
     student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;
     student_ostr << "<tr><td>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
-    if (gradeablesWithExtensions.size() == 0) {
-      student_ostr << "<tr><td>N/a</td></tr>" << std::endl;
-    }
     else {
       for (size_t i2=0;i2<gradeablesWithExtensions.size();i2++) {
         ItemGrade item = std::get<0>(gradeablesWithExtensions[i2]);

--- a/main.cpp
+++ b/main.cpp
@@ -1375,7 +1375,7 @@ void load_student_grades(std::vector<Student*> &students) {
                            }
                            int late_day_exceptions = itr2->value("late_day_exceptions",0);
                           if (late_day_exceptions > 0) {
-                            string reason_for_exception = itr2->value("reason_for_exception","");
+                            std::string reason_for_exception = itr2->value("reason_for_exception","");
                             s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
                           }
                           else s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);

--- a/main.cpp
+++ b/main.cpp
@@ -1373,7 +1373,12 @@ void load_student_grades(std::vector<Student*> &students) {
                              event = "Open";
                              s->set_event_grade_inquiry(true);
                            }
-                          s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);
+                           int late_day_exceptions = itr2->value("late_day_exceptions",0);
+                          if (late_day_exceptions > 0) {
+                            string reason_for_exception = itr2->value("reason_for_exception","");
+                            s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
+                          }
+                          else s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status);
                         }
       }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1740,7 +1740,7 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
     }
     student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
     student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;
-    student_ostr << "<tr><td>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
+    student_ostr << "<tr><td>Gradeable</td><td align=center> Days Extended </td><td align=center>Reason</td><td></td></tr>" << std::endl;
     for (size_t i2=0;i2<gradeablesWithExtensions.size();i2++) {
       ItemGrade item = std::get<0>(gradeablesWithExtensions[i2]);
       GRADEABLE_ENUM g = std::get<0>(std::get<1>(gradeablesWithExtensions[i2]));

--- a/main.cpp
+++ b/main.cpp
@@ -1737,7 +1737,7 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
     
     student_ostr << "<h3> Excused Absence Extensions for: " << username << "</h3>" << std::endl;
     student_ostr << "<table cellpadding=5 style=\"border:1px solid #aaaaaa; background-color:#ffffff;\">" << std::endl;
-    student_ostr << "<tr><td align=center>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
+    student_ostr << "<tr><td>Gradeable</td><td align=center>Days Extended</td><td align=center>Reason</td><td></td></tr>" << std::endl;
     if (gradeablesWithExtensions.size() == 0) {
       student_ostr << "<tr><td>N/a</td></tr>" << std::endl;
     }
@@ -1751,7 +1751,7 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
         }
-        student_ostr << "<tr><td align=center>" << gradeable_name << "</td><td align=center>"
+        student_ostr << "<tr><td>" << gradeable_name << "</td><td align=center>"
                    << item.getLateDayExceptions() << "</td><td align=center>"
                    << item.getReasonForException() << "</td></tr>" << std::endl;
       }

--- a/output.cpp
+++ b/output.cpp
@@ -946,7 +946,7 @@ void start_table_output( bool /*for_instructor*/,
     if (DISPLAY_FINAL_GRADE) {
       std::string g = this_student->grade(false,sd);      
       color = GradeColor(g);
-      if (this_student->getMossPenalty() < -0.01) {
+      if (this_student->getMossPenalty() < -0.00000001) {
         g += "@";
       }
       assert (color.size()==6);
@@ -1175,6 +1175,16 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
 
   ostr << "<p>* = 1 late day used</p>" << std::endl;
 
+
+  bool print_moss_message = false;
+  if (s != NULL && s->getMossPenalty() < -0.0000001) {
+    print_moss_message = true;
+  }
+
+  if (print_moss_message) {
+    ostr << "@ = Academic Integrity Violation penalty<p>&nbsp;<p>\n";
+  }
+
   // Description of border outline that are in effect
   if (s != NULL)
   {
@@ -1232,7 +1242,6 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
   }
 
 
-
   if (s != NULL) {
     std::ifstream istr("student_poll_reports/"+s->getUserName()+".html");
     if (istr.good()) {
@@ -1244,14 +1253,6 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
   }
   ostr << "<p>&nbsp;<p>\n";
 
-  bool print_moss_message = false;
-  if (s != NULL && s->getMossPenalty() < -0.01) {
-    print_moss_message = true;
-  }
-
-  if (print_moss_message) {
-    ostr << "@ = final grade with Academic Integrity Violation penalty<p>&nbsp;<p>\n";
-  }
 
   if (DISPLAY_FINAL_GRADE) { // && students.size() > 50) {
 

--- a/output.cpp
+++ b/output.cpp
@@ -1041,9 +1041,10 @@ void start_table_output( bool /*for_instructor*/,
             details += " " + status;
           }
           int late_days_used = this_student->getGradeableItemGrade(g,j).getLateDaysUsed();
+          int daysExtended = this_student->getGradeableItemGrade(g,j).getLateDayExceptions();
           assert (color.size()==6);
           std::string a = "right";
-          table.set(myrow,counter++,TableCell(grade,color,1,details,late_days_used,visible,event,Academic_integrity,a,1,0,reason,gID,userName));
+          table.set(myrow,counter++,TableCell(grade,color,1,details,late_days_used,visible,event,Academic_integrity,a,1,0,reason,gID,userName,daysExtended));
         }
         table.set(myrow,counter++,TableCell(grey_divider));
 

--- a/output.cpp
+++ b/output.cpp
@@ -1195,7 +1195,7 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
   // Description of border outline that are in effect
   if (s != NULL)
   {
-      if (s->get_event_bad_status() || s->get_event_grade_inquiry() || s->get_event_overridden() || s->get_event_academic_integrity())
+      if (s->get_event_bad_status() || s->get_event_grade_inquiry() || s->get_event_overridden() || s->get_event_academic_integrity() || s->get_event_extension())
       {
         ostr << "<style> .spacer {display: inline-block; width: 66px;} </style>\n";
         ostr << "<table style=\"border:1px solid #aaaaaa; background-color:#FFFFFF;\">\n";
@@ -1217,7 +1217,7 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "<span class=\"spacer\"></span>";
           ostr << "</td>";
           ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
-          ostr << "<font size = \"-1\"> Grade override </font>";
+          ostr << "<font size = \"-1\"> Grade Override </font>";
           ostr << "</td>";
           ostr << "</tr>\n";
         }
@@ -1239,7 +1239,7 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "<span class=\"spacer\"></span>";
           ostr << "</td>";
           ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
-          ostr << "<font size = \"-1\"> Grade inquiry in progress </font>";
+          ostr << "<font size = \"-1\"> Grade Inquiry in Progress </font>";
           ostr << "</td>";
           ostr << "</tr>\n";
         }

--- a/output.cpp
+++ b/output.cpp
@@ -677,7 +677,7 @@ void start_table_output( bool /*for_instructor*/,
       //Late days headers
       student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ALLOWED LATE DAYS"));
       student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","USED LATE DAYS"));
-      student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ALLOWED ABSENCE EXTENSIONS"));
+      student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ABSENCE EXTENSIONS"));
       student_data.push_back(counter);  table.set(0,counter++,TableCell(grey_divider));
     }
   }
@@ -1083,7 +1083,8 @@ void start_table_output( bool /*for_instructor*/,
           color = coloritcolor(allowed-used+2, 5+2, 3+2, 2+2, 1+2, 0+2);
           table.set(myrow,counter++,TableCell(color,used,"",0,CELL_CONTENTS_VISIBLE,"right"));
           int exceptions = this_student->getLateDayExceptions();
-          table.set(myrow,counter++,TableCell("ffffff",exceptions,"",0,CELL_CONTENTS_VISIBLE,"right"));
+          color = coloritcolor(exceptions,5,4,3,2,2);
+          table.set(myrow,counter++,TableCell(color,exceptions,"",0,CELL_CONTENTS_VISIBLE,"right"));
         } else {
           color="ffffff"; // default_color;
           table.set(myrow,counter++,TableCell(color,""));

--- a/output.cpp
+++ b/output.cpp
@@ -1219,6 +1219,17 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "</td>";
           ostr << "</tr>\n";
         }
+        if (s->get_event_extension())
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px solid #0066e0; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Excused Absence Extension </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
         if (s->get_event_grade_inquiry())
         {
           ostr << "<tr>\n";

--- a/output.cpp
+++ b/output.cpp
@@ -1035,13 +1035,15 @@ void start_table_output( bool /*for_instructor*/,
           std::string event = this_student->getGradeableItemGrade(g,j).getEvent();
           bool Academic_integrity = this_student->getGradeableItemGrade(g,j).getAcademicIntegrity();
           std::string reason = this_student->getGradeableItemGrade(g,j).getReasonForException();
+          std::string gID = GRADEABLES[g].getID(j);
+          std::string userName = this_student->getUserName();
           if (status.find("Bad") != std::string::npos) {
             details += " " + status;
           }
           int late_days_used = this_student->getGradeableItemGrade(g,j).getLateDaysUsed();
           assert (color.size()==6);
           std::string a = "right";
-          table.set(myrow,counter++,TableCell(grade,color,1,details,late_days_used,visible,event,Academic_integrity,a,1,0,reason));
+          table.set(myrow,counter++,TableCell(grade,color,1,details,late_days_used,visible,event,Academic_integrity,a,1,0,reason,gID,userName));
         }
         table.set(myrow,counter++,TableCell(grey_divider));
 

--- a/output.cpp
+++ b/output.cpp
@@ -677,6 +677,7 @@ void start_table_output( bool /*for_instructor*/,
       //Late days headers
       student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ALLOWED LATE DAYS"));
       student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","USED LATE DAYS"));
+      student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ALLOWED ABSENCE EXTENSIONS"));
       student_data.push_back(counter);  table.set(0,counter++,TableCell(grey_divider));
     }
   }
@@ -1081,6 +1082,8 @@ void start_table_output( bool /*for_instructor*/,
           int used = this_student->getUsedLateDays();
           color = coloritcolor(allowed-used+2, 5+2, 3+2, 2+2, 1+2, 0+2);
           table.set(myrow,counter++,TableCell(color,used,"",0,CELL_CONTENTS_VISIBLE,"right"));
+          int exceptions = this_student->getLateDayExceptions();
+          table.set(myrow,counter++,TableCell("ffffff",exceptions,"",0,CELL_CONTENTS_VISIBLE,"right"));
         } else {
           color="ffffff"; // default_color;
           table.set(myrow,counter++,TableCell(color,""));

--- a/output.cpp
+++ b/output.cpp
@@ -1034,12 +1034,14 @@ void start_table_output( bool /*for_instructor*/,
           std::string status = this_student->getGradeableItemGrade(g,j).getStatus();
           std::string event = this_student->getGradeableItemGrade(g,j).getEvent();
           bool Academic_integrity = this_student->getGradeableItemGrade(g,j).getAcademicIntegrity();
+          std::string reason = this_student->getGradeableItemGrade(g,j).getReasonForException();
           if (status.find("Bad") != std::string::npos) {
             details += " " + status;
           }
           int late_days_used = this_student->getGradeableItemGrade(g,j).getLateDaysUsed();
           assert (color.size()==6);
-          table.set(myrow,counter++,TableCell(grade,color,1,details,late_days_used,visible,event,Academic_integrity));
+          std::string a = "right";
+          table.set(myrow,counter++,TableCell(grade,color,1,details,late_days_used,visible,event,Academic_integrity,a,1,0,reason));
         }
         table.set(myrow,counter++,TableCell(grey_divider));
 

--- a/output.cpp
+++ b/output.cpp
@@ -1093,6 +1093,7 @@ void start_table_output( bool /*for_instructor*/,
           table.set(myrow,counter++,TableCell(color,""));
           table.set(myrow,counter++,TableCell(color,""));
           table.set(myrow,counter++,TableCell(color,""));
+          table.set(myrow,counter++,TableCell(color,""));
         }
         table.set(myrow,counter++,TableCell(grey_divider));
       }

--- a/output.cpp
+++ b/output.cpp
@@ -677,7 +677,7 @@ void start_table_output( bool /*for_instructor*/,
       //Late days headers
       student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ALLOWED LATE DAYS"));
       student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","USED LATE DAYS"));
-      student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","ABSENCE EXTENSIONS"));
+      student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","EXCUSED EXTENSIONS"));
       student_data.push_back(counter);  table.set(0,counter++,TableCell(grey_divider));
     }
   }
@@ -1248,6 +1248,13 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
 
 
   if (s != NULL) {
+    std::ifstream istr2("student_extension_reports/"+s->getUserName()+".html");
+    if (istr2.good()) {
+      std::string tmp_s;
+      while (getline(istr2,tmp_s)) {
+        ostr << tmp_s;
+      }
+    }
     std::ifstream istr("student_poll_reports/"+s->getUserName()+".html");
     if (istr.good()) {
       std::string tmp_s;

--- a/output.cpp
+++ b/output.cpp
@@ -1223,7 +1223,7 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "</td>";
           ostr << "</tr>\n";
         }
-        if (s->get_event_extension())
+        if (for_instructor || (s != NULL && s->get_event_extension()))
         {
           ostr << "<tr>\n";
           ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px solid #0066e0; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";

--- a/student.cpp
+++ b/student.cpp
@@ -106,24 +106,17 @@ void Student::setGradeableItemGrade_AcademicIntegrity(GRADEABLE_ENUM g, int i, f
   itr->second[i] = ItemGrade(value,late_days_used,note,status,temp,academic_integrity);
 }
 
-void Student::setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event, int late_days_used, const std::string &note, const std::string &status) {
+void Student::setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event, 
+                                           int late_days_used, const std::string &note, const std::string &status, int exceptions, std::string &reason) {
   assert (i >= 0 && i < GRADEABLES[g].getCount());
   std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::iterator itr = all_item_grades.find(g);
   assert (itr != all_item_grades.end());
   assert (int(itr->second.size()) > i);
+  bool temp = false;
     
-  itr->second[i] = ItemGrade(value,late_days_used,note,status,event);
+  itr->second[i] = ItemGrade(value,late_days_used,note,status,event,temp,exceptions,reason);
 }
 
-void Student::setGradeableItemGrade_extension(GRADEABLE_ENUM g, int i, float value, const std::string &event, int late_days_used, const std::string &note, const std::string &status) {
-  assert (i >= 0 && i < GRADEABLES[g].getCount());
-  std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::iterator itr = all_item_grades.find(g);
-  assert (itr != all_item_grades.end());
-  assert (int(itr->second.size()) > i);
-  std::string temp = "";
-    
-  itr->second[i] = ItemGrade(value,late_days_used,note,status,temp,temp,event,days_extension,reason);
-}
 
 
 
@@ -401,11 +394,11 @@ int Student::getUsedLateDays() const {
   return answer;
 }
 
- int Student::getDaysOfExtension() const {
+ int Student::getLateDayExceptions() const {
   int answer = 0;
   for (std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::const_iterator itr = all_item_grades.begin(); itr != all_item_grades.end(); itr++) {
     for (std::size_t i = 0; i < itr->second.size(); i++) {
-      answer += itr->second[i].getDaysOfExtension();
+      answer += itr->second[i].getLateDayExceptions();
     }
   }
   return answer;

--- a/student.cpp
+++ b/student.cpp
@@ -115,6 +115,16 @@ void Student::setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value,
   itr->second[i] = ItemGrade(value,late_days_used,note,status,event);
 }
 
+void Student::setGradeableItemGrade_extension(GRADEABLE_ENUM g, int i, float value, const std::string &event, int late_days_used, const std::string &note, const std::string &status) {
+  assert (i >= 0 && i < GRADEABLES[g].getCount());
+  std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::iterator itr = all_item_grades.find(g);
+  assert (itr != all_item_grades.end());
+  assert (int(itr->second.size()) > i);
+  std::string temp = "";
+    
+  itr->second[i] = ItemGrade(value,late_days_used,note,status,temp,temp,event,days_extension,reason);
+}
+
 
 
 
@@ -390,6 +400,16 @@ int Student::getUsedLateDays() const {
   }
   return answer;
 }
+
+ int Student::getDaysOfExtension() const {
+  int answer = 0;
+  for (std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::const_iterator itr = all_item_grades.begin(); itr != all_item_grades.end(); itr++) {
+    for (std::size_t i = 0; i < itr->second.size(); i++) {
+      answer += itr->second[i].getDaysOfExtension();
+    }
+  }
+  return answer;
+ }
 
 // =============================================================================================
 

--- a/student.cpp
+++ b/student.cpp
@@ -107,7 +107,7 @@ void Student::setGradeableItemGrade_AcademicIntegrity(GRADEABLE_ENUM g, int i, f
 }
 
 void Student::setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event, 
-                                           int late_days_used, const std::string &note, const std::string &status, int exceptions, std::string &reason) {
+                                           int late_days_used, const std::string &note, const std::string &status, int exceptions, const std::string &reason) {
   assert (i >= 0 && i < GRADEABLES[g].getCount());
   std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::iterator itr = all_item_grades.find(g);
   assert (itr != all_item_grades.end());

--- a/student.cpp
+++ b/student.cpp
@@ -488,7 +488,7 @@ void Student::mossify(const std::string &gradeable, float penalty) {
   // but it will be multiplied by a negative and added to the total;
   assert (penalty >= 0);
 
-  moss_penalty += -0.0000001;
+  moss_penalty += -0.0000002;
   moss_penalty += -average_letter_grade * penalty;
   std::stringstream foo;
   foo << std::setprecision(2) << std::fixed << penalty;

--- a/student.cpp
+++ b/student.cpp
@@ -213,7 +213,7 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
     //if(!id.empty() && GRADEABLES[g].isReleased(id)){
     if(!id.empty()){
       m = GRADEABLES[g].getItemMaximum(id);
-      std::cout << "m" << m << std::endl;
+      // std::cout << "m" << m << std::endl;
     }
     float p = GRADEABLES[g].getItemPercentage(id);
     float sm = GRADEABLES[g].getScaleMaximum(id);
@@ -274,7 +274,8 @@ float Student::GradeablePercent(GRADEABLE_ENUM g) const {
       sum_percentage += p;
     }
   }
-  assert(sum_percentage <= 1.0);
+  const float tolerance = 0.000001;
+  assert(sum_percentage <= 1.0 + tolerance);
   if (sum_max == 0) { // pure extra credit category
     sum_percentage = 1.0;
   }

--- a/student.cpp
+++ b/student.cpp
@@ -441,6 +441,20 @@ int Student::getUsedLateDays() const {
   return answer;
  }
 
+ std::vector<std::tuple<ItemGrade,std::tuple<GRADEABLE_ENUM,int> > > Student::getItemsWithExceptions() const {
+  std::vector<std::tuple<ItemGrade,std::tuple<GRADEABLE_ENUM,int> > > result;
+  for (std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::const_iterator itr = all_item_grades.begin(); itr != all_item_grades.end(); itr++) {
+    for (std::size_t i = 0; i < itr->second.size(); i++) {
+      if (itr->second[i].getLateDayExceptions()>0) {
+        std::tuple<GRADEABLE_ENUM,int> indexes{itr->first,i};
+        std::tuple<ItemGrade,std::tuple<GRADEABLE_ENUM,int> > itemInfo{itr->second[i],indexes};
+        result.push_back(itemInfo);
+      }
+    }
+  }
+  return result;
+ }
+
 // =============================================================================================
 
 float Student::overall_b4_academic_sanction() const {

--- a/student.cpp
+++ b/student.cpp
@@ -122,7 +122,6 @@ void Student::setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value,
 
 
 
-
 // =============================================================================================
 // GRADER CALCULATION HELPER FUNCTIONS
 

--- a/student.cpp
+++ b/student.cpp
@@ -112,9 +112,9 @@ void Student::setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value,
   std::map<GRADEABLE_ENUM,std::vector<ItemGrade> >::iterator itr = all_item_grades.find(g);
   assert (itr != all_item_grades.end());
   assert (int(itr->second.size()) > i);
-  bool temp = false;
+  bool academic_integrity = false;
     
-  itr->second[i] = ItemGrade(value,late_days_used,note,status,event,temp,exceptions,reason);
+  itr->second[i] = ItemGrade(value,late_days_used,note,status,event,academic_integrity,exceptions,reason);
 }
 
 

--- a/student.h
+++ b/student.h
@@ -21,12 +21,14 @@ extern std::vector<float> GLOBAL_earned_late_days;
 
 class ItemGrade {
 public:
-  ItemGrade(float v, int ldu=0, const std::string& n="", const std::string &s="", const std::string &e="", bool ai=false) {
+  ItemGrade(float v, int ldu=0, const std::string& n="", const std::string &s="", const std::string &e="", bool ai=false, int de=0, std::string& r="") {
     value = v;
     late_days_used = ldu;
     note = n;
     event = e;
     academic_integrity = ai;
+    days_of_extension = de;
+    reason_for_extension = r;
     
     if (s != "UNKONWN") {
       status = s;
@@ -55,6 +57,8 @@ public:
     return adjusted_value; 
   }
   int getLateDaysUsed() const { return late_days_used; }
+  int getDaysOfExtension() const { return days_of_extension; }
+  const std::string& getReasonForExtension() const { return reason_for_extension; }
   const std::string& getNote() const { return note; }
   const std::string& getStatus() const { return status; }
   const std::string& getEvent() const { return event; }
@@ -63,10 +67,12 @@ public:
 private:
   float value;
   int late_days_used;
+  int days_of_exension;
   bool academic_integrity;
   std::string note;
   std::string status;
   std::string event;
+  std::string reason_for_extension;
 };
 
 //====================================================================
@@ -108,6 +114,7 @@ public:
   int getPollsIncorrect() const;
   float getPollPoints() const;
   int getUsedLateDays() const;
+  int getDaysOfExtension() const;
   float getMossPenalty() const { return moss_penalty; }
 
   void setCurrentAllowedLateDays(int d) { current_allowed_late_days = d; }
@@ -172,7 +179,7 @@ public:
 
   // grade data
   void setTestZone(int which_test, const std::string &zone)  { zones[which_test] = zone; }
-  void setGradeableItemGrade(GRADEABLE_ENUM g, int i, float value, int late_days_used=0, const std::string &note="",const std::string &status="");
+  void setGradeableItemGrade(GRADEABLE_ENUM g, int i, float value, int late_days_used=0, const std::string &note="",const std::string &status=""wa);
   void setGradeableItemGrade_AcademicIntegrity(GRADEABLE_ENUM g, int i, float value, bool academic_integrity, int late_days_used=0, const std::string &note="",const std::string &status="");
   void setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event="", int late_days_used=0, const std::string &note="",const std::string &status="");
 

--- a/student.h
+++ b/student.h
@@ -190,10 +190,12 @@ public:
     void set_event_grade_inquiry(bool value) {grade_inquiry = value;}
     void set_event_overridden(bool value) {overridden = value;}
     void set_event_bad_status(bool value) {bad_status = value;}
+    void set_event_extension(bool value) {extension = value;}
     bool get_event_academic_integrity() {return academic_integrity;}
     bool get_event_grade_inquiry() {return grade_inquiry;}
     bool get_event_overridden() {return overridden;}
     bool get_event_bad_status() {return bad_status;}
+    bool get_event_extension() {return extension;}
 
   // other grade-like data
   void setNumericID(const std::string& r_id) { numeric_id = r_id; }
@@ -255,6 +257,7 @@ private:
   bool grade_inquiry = false;
   bool overridden = false;
   bool bad_status = false;
+  bool extension = false;
 
     // registration status
   std::string section;

--- a/student.h
+++ b/student.h
@@ -115,6 +115,7 @@ public:
   float getPollPoints() const;
   int getUsedLateDays() const;
   int getLateDayExceptions() const;
+  std::vector<std::tuple<ItemGrade,std::tuple<GRADEABLE_ENUM,int> > > getItemsWithExceptions() const;
   float getAcademicSanctionPenalty() const { return academic_sanction_penalty; }
 
   void setCurrentAllowedLateDays(int d) { current_allowed_late_days = d; }

--- a/student.h
+++ b/student.h
@@ -27,8 +27,8 @@ public:
     note = n;
     event = e;
     academic_integrity = ai;
-    days_of_extension = de;
-    reason_for_extension = r;
+    late_day_exceptions = de;
+    reason_for_exception = r;
     
     if (s != "UNKONWN") {
       status = s;
@@ -57,8 +57,8 @@ public:
     return adjusted_value; 
   }
   int getLateDaysUsed() const { return late_days_used; }
-  int getDaysOfExtension() const { return days_of_extension; }
-  const std::string& getReasonForExtension() const { return reason_for_extension; }
+  int getLateDayExceptions() const { return late_day_exceptions; }
+  const std::string& getReasonForException() const { return reason_for_exception; }
   const std::string& getNote() const { return note; }
   const std::string& getStatus() const { return status; }
   const std::string& getEvent() const { return event; }
@@ -67,12 +67,12 @@ public:
 private:
   float value;
   int late_days_used;
-  int days_of_exension;
+  int late_day_exceptions;
   bool academic_integrity;
   std::string note;
   std::string status;
   std::string event;
-  std::string reason_for_extension;
+  std::string reason_for_exception;
 };
 
 //====================================================================
@@ -114,7 +114,7 @@ public:
   int getPollsIncorrect() const;
   float getPollPoints() const;
   int getUsedLateDays() const;
-  int getDaysOfExtension() const;
+  int getLateDayExceptions() const;
   float getMossPenalty() const { return moss_penalty; }
 
   void setCurrentAllowedLateDays(int d) { current_allowed_late_days = d; }
@@ -181,7 +181,7 @@ public:
   void setTestZone(int which_test, const std::string &zone)  { zones[which_test] = zone; }
   void setGradeableItemGrade(GRADEABLE_ENUM g, int i, float value, int late_days_used=0, const std::string &note="",const std::string &status=""wa);
   void setGradeableItemGrade_AcademicIntegrity(GRADEABLE_ENUM g, int i, float value, bool academic_integrity, int late_days_used=0, const std::string &note="",const std::string &status="");
-  void setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event="", int late_days_used=0, const std::string &note="",const std::string &status="");
+  void setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event="", int late_days_used=0, const std::string &note="",const std::string &status="",int exceptions=0,std::string &reason="");
 
   void mossify(const std::string &gradeable, float penalty);
 

--- a/student.h
+++ b/student.h
@@ -21,7 +21,7 @@ extern std::vector<float> GLOBAL_earned_late_days;
 
 class ItemGrade {
 public:
-  ItemGrade(float v, int ldu=0, const std::string& n="", const std::string &s="", const std::string &e="", bool ai=false, int de=0, std::string& r="") {
+  ItemGrade(float v, int ldu=0, const std::string& n="", const std::string &s="", const std::string &e="", bool ai=false, int de=0, const std::string& r="") {
     value = v;
     late_days_used = ldu;
     note = n;
@@ -179,9 +179,9 @@ public:
 
   // grade data
   void setTestZone(int which_test, const std::string &zone)  { zones[which_test] = zone; }
-  void setGradeableItemGrade(GRADEABLE_ENUM g, int i, float value, int late_days_used=0, const std::string &note="",const std::string &status=""wa);
+  void setGradeableItemGrade(GRADEABLE_ENUM g, int i, float value, int late_days_used=0, const std::string &note="",const std::string &status="");
   void setGradeableItemGrade_AcademicIntegrity(GRADEABLE_ENUM g, int i, float value, bool academic_integrity, int late_days_used=0, const std::string &note="",const std::string &status="");
-  void setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event="", int late_days_used=0, const std::string &note="",const std::string &status="",int exceptions=0,std::string &reason="");
+  void setGradeableItemGrade_border(GRADEABLE_ENUM g, int i, float value, const std::string &event="", int late_days_used=0, const std::string &note="",const std::string &status="",int exceptions=0, const std::string &reason="");
 
   void mossify(const std::string &gradeable, float penalty);
 

--- a/table.cpp
+++ b/table.cpp
@@ -253,14 +253,18 @@ void Table::output(std::ostream& ostr,
       ostr << ".hoverable-cell:hover::before {";
       ostr << "    content: attr(data-hover-text);";
       ostr << "    position: absolute;";
-      ostr << "    top: 50%;";
       ostr << "    left: 50%;";
-      ostr << "    transform: translate(-50%, -50%);";
-      ostr << "    background-color: #fff;";
+      ostr << "    bottom: 85%;";
+      ostr << "    width: auto;";
+      ostr << "    height: auto;";
+      ostr << "    background-color: rgba(255, 255, 255, 0.9);"; // semi-opaque white background
       ostr << "    padding: 5px;";
       ostr << "    border: 1px solid #aaa;";
       ostr << "    z-index: 1;";
-      ostr << "    display: block;";
+      ostr << "    display: flex;";
+      ostr << "    align-items: left;";
+      ostr << "    justify-content: left;";
+      ostr << "    box-sizing: border-box;";
       ostr << "}";
       ostr << "</style>";
 

--- a/table.cpp
+++ b/table.cpp
@@ -257,7 +257,7 @@ void Table::output(std::ostream& ostr,
       ostr << "    bottom: 85%;";
       ostr << "    width: auto;";
       ostr << "    height: auto;";
-      ostr << "    background-color: rgba(255, 255, 255, 0.9);"; // semi-opaque white background
+      ostr << "    background-color: rgba(255, 255, 255, 0.88);"; // semi-opaque white background
       ostr << "    padding: 5px;";
       ostr << "    border: 1px solid #aaa;";
       ostr << "    z-index: 1;";

--- a/table.cpp
+++ b/table.cpp
@@ -93,7 +93,10 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   rotate = 0;
   academic_integrity = ai;
   event = e;
-  reason_for_exception = reason;
+  if (reason != "") {
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+reason+"\" ";
+  }
+  else hoverText = "";
   if (event == "Bad"){
     bad_status = true;
     override = inquiry = extension = false;
@@ -134,7 +137,7 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
     
   //  ostr << "<td bgcolor=\"" << c.color << "\" align=\"" << c.align << "\">";
 //  ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
-        ostr << "<td class=\"hoverable-cell\" data-hover-text=\"" << c.reason_for_exception << "\" style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+        ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
   if (0) { //rotate == 90) {
     ostr << "<div style=\"position:relative\"><p class=\"rotate\">";
   }

--- a/table.cpp
+++ b/table.cpp
@@ -95,15 +95,18 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   event = e;
   if (event == "Bad"){
     bad_status = true;
-    override = inquiry = false;
+    override = inquiry = extension = false;
   } else if ( event == "Overridden"){
     override = true;
-    bad_status = inquiry = false;
+    bad_status = inquiry = extension = false;
   } else if (event == "Open"){
     inquiry = true;
-    bad_status = override = false;
+    bad_status = override = extension = false;
+  } else if (event == "Extension"){
+    extension = true;
+    inquiry = bad_status = override = false;
   } else {
-   inquiry = bad_status = override = false; 
+   inquiry = bad_status = override = extension = false; 
   }
     
 }
@@ -120,6 +123,8 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         mark = "@";
     } else if (c.override){
         outline = "outline:4px solid #fcca03; outline-offset: -4px;";
+    } else if (c.extension){
+        outline = "outline:4px solid #0066e0; outline-offset: -4px;";
     } else if (c.inquiry){
         outline = "outline:4px dashed #1cfc03; outline-offset: -4px;";
     } else if (c.bad_status){

--- a/table.cpp
+++ b/table.cpp
@@ -74,7 +74,7 @@ TableCell::TableCell(const std::string& c, float d, int precision, const std::st
 
 
 TableCell::TableCell(float d, const std::string& c, int precision, const std::string& n, int ldu,
-                     CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, int s, int /*r*/) {
+                     CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, int s, int /*r*/,const std::string& reason) {
   assert (c.size() == 6);
   assert (precision >= 0);
   color=c;
@@ -93,6 +93,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   rotate = 0;
   academic_integrity = ai;
   event = e;
+  reason_for_exception = reason;
   if (event == "Bad"){
     bad_status = true;
     override = inquiry = extension = false;
@@ -133,7 +134,7 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
     
   //  ostr << "<td bgcolor=\"" << c.color << "\" align=\"" << c.align << "\">";
 //  ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
-        ostr << "<td class=\"hoverable-cell\" data-hover-text=\"" << c.hoverText << "\" style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+        ostr << "<td class=\"hoverable-cell\" data-hover-text=\"" << c.reason_for_exception << "\" style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
   if (0) { //rotate == 90) {
     ostr << "<div style=\"position:relative\"><p class=\"rotate\">";
   }

--- a/table.cpp
+++ b/table.cpp
@@ -75,7 +75,7 @@ TableCell::TableCell(const std::string& c, float d, int precision, const std::st
 
 TableCell::TableCell(float d, const std::string& c, int precision, const std::string& n, int ldu,
                      CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, 
-                     int s, int /*r*/,const std::string& reason,const std::string& gID,const std::string& userName) {
+                     int s, int /*r*/,const std::string& reason,const std::string& gID,const std::string& userName, int daysExtended) {
   assert (c.size() == 6);
   assert (precision >= 0);
   color=c;
@@ -95,7 +95,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   academic_integrity = ai;
   event = e;
   if (reason != "") {
-    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+gID+"\n"+userName+"\n"+reason+"\" ";
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension due to "+reason+" on "+gID+"\" ";
   }
   else hoverText = "";
   if (event == "Bad"){
@@ -252,10 +252,10 @@ void Table::output(std::ostream& ostr,
       ostr << ".hoverable-cell:hover::before {";
       ostr << "    content: attr(data-hover-text);";
       ostr << "    position: absolute;";
-      ostr << "    white-space: pre-line;";
+      ostr << "    text-align: left;";
       ostr << "    left: 50%;";
       ostr << "    bottom: 85%;";
-      ostr << "    width: auto;";
+      ostr << "    width: 500%;";
       ostr << "    height: auto;";
       ostr << "    background-color: rgba(255, 255, 255, 0.88);"; // semi-opaque white background
       ostr << "    padding: 5px;";

--- a/table.cpp
+++ b/table.cpp
@@ -132,8 +132,8 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
     }
     
   //  ostr << "<td bgcolor=\"" << c.color << "\" align=\"" << c.align << "\">";
-  ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
-    
+//  ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+        ostr << "<td class=\"hoverable-cell\" data-hover-text=\"" << c.hoverText << "\" style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
   if (0) { //rotate == 90) {
     ostr << "<div style=\"position:relative\"><p class=\"rotate\">";
   }
@@ -241,10 +241,32 @@ void Table::output(std::ostream& ostr,
       if (last_update != "") {
           ostr << "<em>Information last updated: " << last_update << "</em><br>\n";
       }
+
+      ostr << "<style>";
+      ostr << ".hoverable-cell {";
+      ostr << "    position: relative;";
+      ostr << "}";
+      ostr << ".hoverable-cell:hover::before {";
+      ostr << "    content: attr(data-hover-text);";
+      ostr << "    position: absolute;";
+      ostr << "    top: 50%;";
+      ostr << "    left: 50%;";
+      ostr << "    transform: translate(-50%, -50%);";
+      ostr << "    background-color: #fff;";
+      ostr << "    padding: 5px;";
+      ostr << "    border: 1px solid #aaa;";
+      ostr << "    z-index: 1;";
+      ostr << "    display: block;";
+      ostr << "}";
+      ostr << "</style>";
+
+
       ostr << "&nbsp;<br>\n";
       ostr << "<table style=\"border:1px solid #aaaaaa; background-color:#aaaaaa;\">\n";
   }
-  
+
+
+
   if (transpose) {
     for (std::vector<int>::iterator c = which_data.begin(); c != which_data.end(); c++) {
       ostr << "<tr>\n";

--- a/table.cpp
+++ b/table.cpp
@@ -74,7 +74,8 @@ TableCell::TableCell(const std::string& c, float d, int precision, const std::st
 
 
 TableCell::TableCell(float d, const std::string& c, int precision, const std::string& n, int ldu,
-                     CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, int s, int /*r*/,const std::string& reason) {
+                     CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, 
+                     int s, int /*r*/,const std::string& reason,const std::string& gID,const std::string& userName) {
   assert (c.size() == 6);
   assert (precision >= 0);
   color=c;
@@ -94,7 +95,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   academic_integrity = ai;
   event = e;
   if (reason != "") {
-    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+reason+"\" ";
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+gID+"\n"+userName+"\n"+reason+"\" ";
   }
   else hoverText = "";
   if (event == "Bad"){
@@ -135,9 +136,7 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         outline = "outline:4px solid #fc0303; outline-offset: -4px;";
     }
     
-  //  ostr << "<td bgcolor=\"" << c.color << "\" align=\"" << c.align << "\">";
-//  ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
-        ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+    ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
   if (0) { //rotate == 90) {
     ostr << "<div style=\"position:relative\"><p class=\"rotate\">";
   }
@@ -253,6 +252,7 @@ void Table::output(std::ostream& ostr,
       ostr << ".hoverable-cell:hover::before {";
       ostr << "    content: attr(data-hover-text);";
       ostr << "    position: absolute;";
+      ostr << "    white-space: pre-line;";
       ostr << "    left: 50%;";
       ostr << "    bottom: 85%;";
       ostr << "    width: auto;";

--- a/table.h
+++ b/table.h
@@ -25,7 +25,7 @@ public:
             CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& a="right", int s=1, int r=0);
   TableCell(float              d   ,const std::string& c         , int precision, const std::string& n="", int ldu=0,
             CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& e="", bool ai = false, const std::string& a="right",
-            int s=1, int r=0, const std::string& reason="",const std::string& gID="",const std::string& userName="");
+            int s=1, int r=0, const std::string& reason="",const std::string& gID="",const std::string& userName="",int daysExtended=0);
   
   std::string make_cell_string(bool csv_mode) const;
   std::string color;

--- a/table.h
+++ b/table.h
@@ -35,6 +35,7 @@ public:
   bool inquiry = false;
   bool bad_status = false;
   bool override = false;
+  bool extension = false;
   std::string align;
   enum CELL_CONTENTS_STATUS visible;
   int span;

--- a/table.h
+++ b/table.h
@@ -24,7 +24,7 @@ public:
   TableCell(const std::string& c         , float              d   , int precision, const std::string& n="", int ldu=0,
             CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& a="right", int s=1, int r=0);
   TableCell(float              d   ,const std::string& c         , int precision, const std::string& n="", int ldu=0,
-            CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& e="", bool ai = false, const std::string& a="right", int s=1, int r=0);
+            CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& e="", bool ai = false, const std::string& a="right", int s=1, int r=0, const std::string& reason="");
   
   std::string make_cell_string(bool csv_mode) const;
   std::string color;
@@ -36,6 +36,7 @@ public:
   bool bad_status = false;
   bool override = false;
   bool extension = false;
+  std::string reason_for_exception = "";
   std::string align;
   enum CELL_CONTENTS_STATUS visible;
   int span;

--- a/table.h
+++ b/table.h
@@ -36,7 +36,7 @@ public:
   bool bad_status = false;
   bool override = false;
   bool extension = false;
-  std::string reason_for_exception = "";
+  std::string hoverText = "";
   std::string align;
   enum CELL_CONTENTS_STATUS visible;
   int span;

--- a/table.h
+++ b/table.h
@@ -24,7 +24,8 @@ public:
   TableCell(const std::string& c         , float              d   , int precision, const std::string& n="", int ldu=0,
             CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& a="right", int s=1, int r=0);
   TableCell(float              d   ,const std::string& c         , int precision, const std::string& n="", int ldu=0,
-            CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& e="", bool ai = false, const std::string& a="right", int s=1, int r=0, const std::string& reason="");
+            CELL_CONTENTS_STATUS v=CELL_CONTENTS_VISIBLE, const std::string& e="", bool ai = false, const std::string& a="right",
+            int s=1, int r=0, const std::string& reason="",const std::string& gID="",const std::string& userName="");
   
   std::string make_cell_string(bool csv_mode) const;
   std::string color;


### PR DESCRIPTION
Previously, no information on a student's late day exceptions were provided in rainbow grades. Now, all excused extension information is collected and stored in each student object. A row was added to the main rainbow grades table to display a student's total number of extensions, and a breakout table was added underneath the main table to display information about each individual extension. Additonally, a blue outline was added to table cell with excused extensions and text giving extension information is listed on hover.

Picture of changes to tables:
![image](https://github.com/Submitty/RainbowGrades/assets/143554378/fa8ab970-20bb-4382-a8c0-a1baf664297c)
Hover Feature:
![image](https://github.com/Submitty/RainbowGrades/assets/143554378/cf243ae3-5f67-4f19-b379-77f791e44a51)

