### PR TITLE
[RainbowGrades:Feature] add display options

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -775,12 +775,26 @@ void preprocesscustomizationfile(const std::string &now_string,
       DISPLAY_GRADE_DETAILS = true;
     } else if (token == "display_rank_to_individual"){
       DISPLAY_RANK_TO_INDIVIDUAL = true;
+    } else if (token == "display_benchmark") {
+      continue;
+    } else if (token == "benchmark_percent") {
+      continue;
+    } else if (token == "section") {
+      continue;
+    } else if (token == "messages") {
+      continue;
+    } else if (token == "warning") {
+      continue;
+    } else if (token == "manual_grade"){
+      continue;
+    } else if (token == "final_cutoff"){
+      continue;
     } else {
       std::cout << "OOPS " << token << std::endl;
       exit(0);
     }
   }
-  
+
   //std::cout << "4" << std::endl;
   
   // Set Display Benchmark


### PR DESCRIPTION
Currently in web-based customization page, we have display option, which is acts like a switch to enable and disable contents that needs to be displayed to students. There are currently 7 options, which are available, but we will expand these features to 14 options. It is a valid checkbox on the Web GUI, but RainbowGrades cannot take the new 7 options, and will silently break if the new options are checked. Hence, this PR will fix it by adding a placeholder to handle additional tokens in display options. 
