### PR TITLE
[Feature:RainbowGrades] Version conflict borderline

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1377,9 +1377,10 @@ void load_student_grades(std::vector<Student*> &students) {
                              event = "Bad";
                              s->set_event_bad_status(true);
                            }
-                           if (status_check == "Overridden") {
-                             event = "Overridden";
-                             s->set_event_overridden(true);
+                           std::string version_conflict = itr2->value("version_conflict", "");
+                           if (version_conflict == "true") {
+                             event = "Version_conflict";
+                             s->set_event_version_conflict(true);
                            }
                            std::string inquiry = itr2->value("inquiry", "");
                            if ((inquiry != "None") && (inquiry != "Resolved") && (inquiry != "")) {
@@ -1393,6 +1394,11 @@ void load_student_grades(std::vector<Student*> &students) {
                              event = "Extension";
                              s->set_event_extension(true);
                            }
+                           // Above itr2 status check, but in order of priority
+                           if (status_check == "Overridden") {
+                             event = "Overridden";
+                             s->set_event_overridden(true);
+                             }
                            s->setGradeableItemGrade_border(g,which,score,event,late_days_charged,other_note,status,late_day_exceptions,reason_for_exception);
                         }
       }

--- a/main.cpp
+++ b/main.cpp
@@ -1382,6 +1382,10 @@ void load_student_grades(std::vector<Student*> &students) {
                              event = "Version_conflict";
                              s->set_event_version_conflict(true);
                            }
+                           if (status_check == "Cancelled") {
+                             event = "Cancelled";
+                             s->set_event_cancelled(true);
+                           }
                            std::string inquiry = itr2->value("inquiry", "");
                            if ((inquiry != "None") && (inquiry != "Resolved") && (inquiry != "")) {
                              assert(inquiry == "Open");

--- a/output.cpp
+++ b/output.cpp
@@ -1207,8 +1207,8 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
         ostr << "<span class=\"spacer\"></span>";
         ostr << "</td>";
         ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
-        ostr << "<font size = \"-1\"> Border-Outline is ranked from top to bottom </font>";
-        ostr << "<span class=\"spacer\"></span> Higher ranked outline will over-write  </font>";
+        ostr << "<font size = \"-1\"> Border-Outline is ranked from top to bottom <br>";
+        ostr << "Higher ranked outline will over-write  </font>";
         ostr << "</td>";
         ostr << "</tr>\n";
         if (for_instructor || (s != NULL && s->get_event_academic_integrity()))
@@ -1263,7 +1263,7 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "</td>";
           ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
           ostr << "<font size = \"-1\"> Version conflict = version conflict between <br> ";
-          ostr << "<span class=\"spacer\"></span> TA graded version and Active version  </font>";
+          ostr << "<span class=\"spacer\"></span> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TA graded version and Active version  </font>";
           ostr << "</td>";
           ostr << "</tr>\n";
         }

--- a/output.cpp
+++ b/output.cpp
@@ -1262,7 +1262,7 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "<span class=\"spacer\"></span>";
           ostr << "</td>";
           ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
-          ostr << "<font size = \"-1\"> Cancelled version </font>";
+          ostr << "<font size = \"-1\"> Cancelled submission </font>";
           ostr << "</td>";
           ostr << "</tr>\n";
         }

--- a/output.cpp
+++ b/output.cpp
@@ -1255,6 +1255,17 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "</td>";
           ostr << "</tr>\n";
         }
+       if (for_instructor || (s != NULL && s->get_event_cancelled()))
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px dashed #0a0a0a; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Cancelled version </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
        if (for_instructor || (s != NULL && s->get_event_version_conflict()))
         {
           ostr << "<tr>\n";

--- a/output.cpp
+++ b/output.cpp
@@ -1202,6 +1202,15 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
       {
         ostr << "<style> .spacer {display: inline-block; width: 66px;} </style>\n";
         ostr << "<table style=\"border:1px solid #aaaaaa; background-color:#FFFFFF;\">\n";
+        ostr << "<tr>\n";
+        ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+        ostr << "<span class=\"spacer\"></span>";
+        ostr << "</td>";
+        ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+        ostr << "<font size = \"-1\"> Border-Outline is ranked from top to bottom </font>";
+        ostr << "<span class=\"spacer\"></span> Higher ranked outline will over-write  </font>";
+        ostr << "</td>";
+        ostr << "</tr>\n";
         if (for_instructor || (s != NULL && s->get_event_academic_integrity()))
         {
           ostr << "<tr>\n";
@@ -1243,6 +1252,18 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
           ostr << "</td>";
           ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
           ostr << "<font size = \"-1\"> Grade Inquiry in Progress </font>";
+          ostr << "</td>";
+          ostr << "</tr>\n";
+        }
+       if (for_instructor || (s != NULL && s->get_event_version_conflict()))
+        {
+          ostr << "<tr>\n";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << "outline:4px dashed #fc0303; outline-offset: -4px;" << " \" align=\"" << "left" << "\">";
+          ostr << "<span class=\"spacer\"></span>";
+          ostr << "</td>";
+          ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#FFFFFF" << "; " << " \" align=\"" << "left" << "\">";
+          ostr << "<font size = \"-1\"> Version conflict = version conflict between <br> ";
+          ostr << "<span class=\"spacer\"></span> TA graded version and Active version  </font>";
           ostr << "</td>";
           ostr << "</tr>\n";
         }

--- a/student.h
+++ b/student.h
@@ -186,16 +186,21 @@ public:
 
   void academic_sanction(const std::string &gradeable, float penalty);
 
+   //set in order of priority - top to bottom
     void set_event_academic_integrity(bool value) {academic_integrity = value;}
-    void set_event_grade_inquiry(bool value) {grade_inquiry = value;}
     void set_event_overridden(bool value) {overridden = value;}
-    void set_event_bad_status(bool value) {bad_status = value;}
     void set_event_extension(bool value) {extension = value;}
+    void set_event_grade_inquiry(bool value) {grade_inquiry = value;}
+    void set_event_version_conflict(bool value) {version_conflict = value;}
+    void set_event_bad_status(bool value) {bad_status = value;}
+
+    //bool in order of priority - top to bottom
     bool get_event_academic_integrity() {return academic_integrity;}
-    bool get_event_grade_inquiry() {return grade_inquiry;}
     bool get_event_overridden() {return overridden;}
-    bool get_event_bad_status() {return bad_status;}
     bool get_event_extension() {return extension;}
+    bool get_event_grade_inquiry() {return grade_inquiry;}
+    bool get_event_version_conflict() {return version_conflict;}
+    bool get_event_bad_status() {return bad_status;}
 
   // other grade-like data
   void setNumericID(const std::string& r_id) { numeric_id = r_id; }
@@ -254,10 +259,11 @@ private:
   int current_allowed_late_days;
   int default_allowed_late_days;
   bool academic_integrity = false;
-  bool grade_inquiry = false;
   bool overridden = false;
-  bool bad_status = false;
   bool extension = false;
+  bool grade_inquiry = false;
+  bool version_conflict = false;
+  bool bad_status = false;
 
     // registration status
   std::string section;

--- a/student.h
+++ b/student.h
@@ -191,6 +191,7 @@ public:
     void set_event_overridden(bool value) {overridden = value;}
     void set_event_extension(bool value) {extension = value;}
     void set_event_grade_inquiry(bool value) {grade_inquiry = value;}
+    void set_event_cancelled(bool value) {cancelled = value;}
     void set_event_version_conflict(bool value) {version_conflict = value;}
     void set_event_bad_status(bool value) {bad_status = value;}
 
@@ -199,6 +200,7 @@ public:
     bool get_event_overridden() {return overridden;}
     bool get_event_extension() {return extension;}
     bool get_event_grade_inquiry() {return grade_inquiry;}
+    bool get_event_cancelled() {return cancelled;}
     bool get_event_version_conflict() {return version_conflict;}
     bool get_event_bad_status() {return bad_status;}
 
@@ -263,6 +265,7 @@ private:
   bool extension = false;
   bool grade_inquiry = false;
   bool version_conflict = false;
+  bool cancelled = false;
   bool bad_status = false;
 
     // registration status

--- a/table.cpp
+++ b/table.cpp
@@ -94,24 +94,32 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   rotate = 0;
   academic_integrity = ai;
   event = e;
+
   if (reason != "") {
     hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension due to "+reason+" on "+gID+"\" ";
+  } else {
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension without specified reason" on "+gID+"\" ";
   }
-  else hoverText = "";
-  if (event == "Bad"){
-    bad_status = true;
-    override = inquiry = extension = false;
-  } else if ( event == "Overridden"){
+
+// Bool in order of priority - top to bottom
+// Don't think we need this logic, but leaving it as sort of assert
+  if (event == "Overridden"){
     override = true;
-    bad_status = inquiry = extension = false;
-  } else if (event == "Open"){
-    inquiry = true;
-    bad_status = override = extension = false;
+    bad_status = inquiry = extension = version_conflict =  false;
   } else if (event == "Extension"){
     extension = true;
+    inquiry = bad_status = override = version_conflict = false;
+  } else if (event == "Open"){
+    inquiry = true;
+    bad_status = override = extension = version_conflict = false;
+  } else if (event == "Version_conflict"){
+    version_conflict = true;
     inquiry = bad_status = override = false;
+  } else if (event == "Bad"){
+    bad_status = true;
+    override = inquiry = extension = version_conflict = false;
   } else {
-   inquiry = bad_status = override = extension = false; 
+   inquiry = bad_status = override = extension = version_conflict = false;
   }
     
 }
@@ -132,6 +140,8 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         outline = "outline:4px solid #0066e0; outline-offset: -4px;";
     } else if (c.inquiry){
         outline = "outline:4px dashed #1cfc03; outline-offset: -4px;";
+    } else if (c.version_conflict){
+        outline = "outline:4px dashed #fc0303; outline-offset: -4px;";
     } else if (c.bad_status){
         outline = "outline:4px solid #fc0303; outline-offset: -4px;";
     }

--- a/table.cpp
+++ b/table.cpp
@@ -105,21 +105,24 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
 // Don't think we need this logic, but leaving it as sort of assert
   if (event == "Overridden"){
     override = true;
-    bad_status = inquiry = extension = version_conflict =  false;
+    bad_status = inquiry = extension = version_conflict = cancelled = false;
   } else if (event == "Extension"){
     extension = true;
-    inquiry = bad_status = override = version_conflict = false;
+    inquiry = bad_status = override = version_conflict = cancelled = false;
   } else if (event == "Open"){
     inquiry = true;
-    bad_status = override = extension = version_conflict = false;
+    bad_status = override = extension = version_conflict = cancelled = false;
+  } else if (event == "Cancelled"){
+    cancelled = true;
+    inquiry = bad_status = override = extension = version_conflict = false;
   } else if (event == "Version_conflict"){
     version_conflict = true;
-    inquiry = bad_status = override = false;
+    inquiry = bad_status = override = extension = cancelled = false;
   } else if (event == "Bad"){
     bad_status = true;
-    override = inquiry = extension = version_conflict = false;
+    override = inquiry = extension = version_conflict = cancelled = false;
   } else {
-   inquiry = bad_status = override = extension = version_conflict = false;
+   inquiry = bad_status = override = extension = version_conflict = cancelled = false;
   }
     
 }
@@ -140,13 +143,21 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         outline = "outline:4px solid #0066e0; outline-offset: -4px;";
     } else if (c.inquiry){
         outline = "outline:4px dashed #1cfc03; outline-offset: -4px;";
+    } else if (c.cancelled){
+        outline = "outline:4px dashed #0a0a0a; outline-offset: -4px;";
     } else if (c.version_conflict){
         outline = "outline:4px dashed #fc0303; outline-offset: -4px;";
     } else if (c.bad_status){
         outline = "outline:4px solid #fc0303; outline-offset: -4px;";
     }
-    
-    ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+
+    if (c.extension){
+        ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+    } else {
+        ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+
+    }
+
   if (0) { //rotate == 90) {
     ostr << "<div style=\"position:relative\"><p class=\"rotate\">";
   }

--- a/table.cpp
+++ b/table.cpp
@@ -98,7 +98,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   if (reason != "") {
     hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension due to "+reason+" on "+gID+"\" ";
   } else {
-    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension without specified reason" on "+gID+"\" ";
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension without specified reason on "+gID+"\" ";
   }
 
 // Bool in order of priority - top to bottom

--- a/table.h
+++ b/table.h
@@ -37,6 +37,7 @@ public:
   bool override = false;
   bool extension = false;
   bool inquiry = false;
+  bool cancelled = false;
   bool version_conflict = false;
   bool bad_status = false;
   std::string hoverText = "";

--- a/table.h
+++ b/table.h
@@ -32,11 +32,13 @@ public:
   std::string data;
   std::string event;
   int late_days_used;
+  // Bool in order of priority - top to bottom
   bool academic_integrity = false;
-  bool inquiry = false;
-  bool bad_status = false;
   bool override = false;
   bool extension = false;
+  bool inquiry = false;
+  bool version_conflict = false;
+  bool bad_status = false;
   std::string hoverText = "";
   std::string align;
   enum CELL_CONTENTS_STATUS visible;


### PR DESCRIPTION
The new change will now include version conflict in request of @KCony
This is related to /Submitty/Submitty/issues/9674
And has connected PR in /Submitty/Submitty/pull/10063

If there is a conflict between TA graded version and Automated version, we call it version conflict.
The current border-outline does not indicate if it is 

One corner case I can mention is that version conflict will also count canceled submission.



<img width="322" alt="Screen Shot 2023-12-13 at 3 33 52 AM" src="https://github.com/Submitty/RainbowGrades/assets/123261952/aa1052a5-b2de-4c4d-b680-dd8dfcdb3af5">


<img width="747" alt="Screen Shot 2023-12-13 at 2 43 27 AM" src="https://github.com/Submitty/RainbowGrades/assets/123261952/ab86a998-bdc7-4e4c-8ba8-b760717c2973">
