### PR TITLE
[Bugfix:RainbowGrades] replace poll status with end_date

### DIFF
--- a/submini_polls.cpp
+++ b/submini_polls.cpp
@@ -110,7 +110,18 @@ void LoadPolls(const std::vector<Student*> &students) {
     std::string question_type = "single-response-multiple-correct";
     nlohmann::json::iterator itr2 = itr->find("question_type");
     if (itr2 != itr->end()) question_type = itr2->get<std::string>();
-    std::string status = itr->find("status")->get<std::string>();
+
+    std::string status = "ended";
+    // original format: status stored as string
+    if (itr->find("status")!=itr->end()) status = itr->find("status")->get<std::string>();
+    // new format (April 2024): polls have an end time
+    std::string end_time = "";
+    if (itr->find("end_time") != itr->end()) end_time = itr->find("end_time")->get<std::string>();
+    if (end_time != "") {
+      // TODO: Parse the date and compare to "now"
+      // if end_date < now => status = "ended";
+      // if end_date > now => status = "closed";
+    }
     assert (status == "ended" || status == "closed" || status == "open");
 
     std::string lecture;


### PR DESCRIPTION
Submini polls now feature an option to use a timer to automatically close/end the poll
https://github.com/Submitty/Submitty/pull/10184

This PR updates the parsing of the output files from generate grade summaries to handle both the old format ("status") and the new format ("end_date")

Note: The end_date does not currently contain a timestamp.  This code may need further revision if/when that is added.