### PR TITLE
[Bugfix:RainbowGrades] Correct Handle of ExtraCredit 

### DIFF
--- a/gradeable.h
+++ b/gradeable.h
@@ -119,6 +119,10 @@ public:
     assert (released.find(id) != released.end());
     return released.find(id)->second;
   }
+  bool isExtraCredit(const std::string &id) const {
+//    assert (extracreditmap.find(id) != extracreditmap.end());
+    return extracreditmap.find(id)->second;
+  }
   float getItemMaximum(const std::string &id) const {
     if (maximums.find(id) == maximums.end()){
       return 0;
@@ -181,6 +185,12 @@ public:
     released[id] = is_released;
   }
 
+  void setExtraCredit(const std::string&id, bool is_extracredit) {
+    assert (hasCorrespondence(id));
+    assert (extracreditmap.find(id) == extracreditmap.end());
+      extracreditmap[id] = is_extracredit;
+  }
+
   void setMaximum(const std::string&id, float maximum) {
     assert (hasCorrespondence(id));
     assert (maximums.find(id) == maximums.end());
@@ -230,6 +240,7 @@ private:
   std::vector<float> sorted_weights;
   std::map<std::string,float> clamps;
   std::map<std::string,bool> released;
+  std::map<std::string,bool> extracreditmap;
   std::map<std::string,std::string> original_ids;
   std::map<std::string,std::string> resubmit_ids;
   std::map<std::string,float> autograde_replacement_percentages;

--- a/main.cpp
+++ b/main.cpp
@@ -647,6 +647,11 @@ void preprocesscustomizationfile(const std::string &now_string,
         GRADEABLES[g].setReleased(token_key,released);
       }
 
+      bool extra_credit = grade_id.value("extra_credit", false);
+      if (extra_credit) {
+          GRADEABLES[g].setExtraCredit(token_key,extra_credit);
+      }
+
       float maximum = grade_id.value("max",0.0);
       GRADEABLES[g].setMaximum(token_key,maximum);
 


### PR DESCRIPTION
Current Submitty has issue with remove lowest and extra credit homework. 


Suppose a student has the following homework grades (each has max 50 points):
42 45 40 44 46 48 49 50 35 (the last one is extra credit HW9)

Following the same criteria of dropping the lowest 2 homework assignments and considering the last one as optional extra credit, the computation should yield:

Currently, Submitty drop the lowest 2 grades: 40 and 35 are dropped.
However, Last one is extra credit so should not get dropped, instead 40, 42 should be dropped. 

This patch fixes above error. Below is example of above mentioned scenario.

![스크린샷 2024-05-07 오전 3 56 32](https://github.com/Submitty/RainbowGrades/assets/123261952/38275098-1f2d-46a7-8b28-95aec9a9f03d)


<img width="730" alt="스크린샷 2024-05-07 오전 3 57 22" src="https://github.com/Submitty/RainbowGrades/assets/123261952/fe6c3ff4-b50d-4399-a89f-55c814bc5d50">


