### PR TITLE
[Feature:RainbowGrades] Adding hover text to bad status cells 

### DIFF
--- a/table.cpp
+++ b/table.cpp
@@ -104,6 +104,8 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
     inquiry = bad_status = override = version_conflict = cancelled = false;
       if (reason != ""){
       hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
+      } else {
+      hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension without specified reason on "+gID+"\" ";
       }
   } else if (event == "Open"){
     inquiry = true;

--- a/table.cpp
+++ b/table.cpp
@@ -72,7 +72,6 @@ TableCell::TableCell(const std::string& c, float d, int precision, const std::st
   rotate = 0;
 }
 
-
 TableCell::TableCell(float d, const std::string& c, int precision, const std::string& n, int ldu,
                      CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, 
                      int s, int /*r*/,const std::string& reason,const std::string& gID,const std::string& userName, int daysExtended) {
@@ -95,10 +94,14 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   academic_integrity = ai;
   event = e;
 
-  if (reason != "") {
-    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension due to "+reason+" on "+gID+"\" ";
-  } else {
-    hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension without specified reason on "+gID+"\" ";
+  if (event == "Extension") {
+      extension = true;
+      inquiry = bad_status = override = version_conflict = cancelled = false;
+      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
+  } else if (event == "Bad") {
+      bad_status = true;
+      override = inquiry = extension = version_conflict = cancelled = false;
+      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a bad status\" ";
   }
 
 // Bool in order of priority - top to bottom
@@ -151,11 +154,10 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         outline = "outline:4px solid #fc0303; outline-offset: -4px;";
     }
 
-    if (c.extension){
-        ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
+    if (c.extension || c.bad_status) {
+        ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "\" align=\"" << c.align << "\">";
     } else {
-        ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << " \" align=\"" << c.align << "\">";
-
+        ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "\" align=\"" << c.align << "\">";
     }
 
   if (0) { //rotate == 90) {

--- a/table.cpp
+++ b/table.cpp
@@ -94,21 +94,15 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   academic_integrity = ai;
   event = e;
 
-  if (event == "Extension" && reason != "") {
-      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
-  } else if (event == "Bad") {
-      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a bad status on " + gID + "\" ";
-      }
-  
-
 // Bool in order of priority - top to bottom
 // Don't think we need this logic, but leaving it as sort of assert
   if (event == "Overridden"){
     override = true;
     bad_status = inquiry = extension = version_conflict = cancelled = false;
-  } else if (event == "Extension"){
+  } else if (event == "Extension" && reason != ""){
     extension = true;
     inquiry = bad_status = override = version_conflict = cancelled = false;
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
   } else if (event == "Open"){
     inquiry = true;
     bad_status = override = extension = version_conflict = cancelled = false;
@@ -121,6 +115,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   } else if (event == "Bad"){
     bad_status = true;
     override = inquiry = extension = version_conflict = cancelled = false;
+    hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a bad status on " + gID + "\" ";
   } else {
    inquiry = bad_status = override = extension = version_conflict = cancelled = false;
   }

--- a/table.cpp
+++ b/table.cpp
@@ -102,9 +102,9 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   } else if (event == "Extension"){
     extension = true;
     inquiry = bad_status = override = version_conflict = cancelled = false;
-    if (reason != ""){
-    hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
-    }
+      if (reason != ""){
+      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
+      }
   } else if (event == "Open"){
     inquiry = true;
     bad_status = override = extension = version_conflict = cancelled = false;

--- a/table.cpp
+++ b/table.cpp
@@ -99,10 +99,12 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   if (event == "Overridden"){
     override = true;
     bad_status = inquiry = extension = version_conflict = cancelled = false;
-  } else if (event == "Extension" && reason != ""){
+  } else if (event == "Extension"){
     extension = true;
     inquiry = bad_status = override = version_conflict = cancelled = false;
+    if (reason != ""){
     hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
+    }
   } else if (event == "Open"){
     inquiry = true;
     bad_status = override = extension = version_conflict = cancelled = false;

--- a/table.cpp
+++ b/table.cpp
@@ -102,11 +102,11 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   } else if (event == "Extension"){
     extension = true;
     inquiry = bad_status = override = version_conflict = cancelled = false;
-      if (reason != ""){
+    if (reason != ""){
       hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
-      } else {
+    } else {
       hoverText = "class=\"hoverable-cell\" data-hover-text=\""+userName+" received a "+std::to_string(daysExtended)+" day extension without specified reason on "+gID+"\" ";
-      }
+    }
   } else if (event == "Open"){
     inquiry = true;
     bad_status = override = extension = version_conflict = cancelled = false;

--- a/table.cpp
+++ b/table.cpp
@@ -95,12 +95,8 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   event = e;
 
   if (event == "Extension" && reason != "") {
-      extension = true;
-      inquiry = bad_status = override = version_conflict = cancelled = false;
       hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";
   } else if (event == "Bad") {
-      bad_status = true;
-      override = inquiry = extension = version_conflict = cancelled = false;
       hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a bad status on " + gID + "\" ";
       }
   
@@ -129,7 +125,6 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
    inquiry = bad_status = override = extension = version_conflict = cancelled = false;
   }
 }
-
 
 
 

--- a/table.cpp
+++ b/table.cpp
@@ -94,7 +94,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   academic_integrity = ai;
   event = e;
 
-  if (event == "Extension") {
+  if (event == "Extension" && reason != "") {
       extension = true;
       inquiry = bad_status = override = version_conflict = cancelled = false;
       hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a " + std::to_string(daysExtended) + " day extension due to " + reason + " on " + gID + "\" ";

--- a/table.cpp
+++ b/table.cpp
@@ -101,8 +101,9 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   } else if (event == "Bad") {
       bad_status = true;
       override = inquiry = extension = version_conflict = cancelled = false;
-      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a bad status\" ";
-  }
+      hoverText = "class=\"hoverable-cell\" data-hover-text=\"" + userName + " received a bad status on " + gID + "\" ";
+      }
+  
 
 // Bool in order of priority - top to bottom
 // Don't think we need this logic, but leaving it as sort of assert
@@ -127,8 +128,8 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
   } else {
    inquiry = bad_status = override = extension = version_conflict = cancelled = false;
   }
-    
 }
+
 
 
 


### PR DESCRIPTION
**What is the current behavior?**
Students aren't sure what the red outline on the grade report means since the description is at the bottom of the grade report page. 

**What is the new behavior?**
A hover feature is now implemented to notify that the red outline cells are bad status, including the username of the student with a bad status and the homework/assignment that a bad status was received.

**Other information?**
Fixes Submitty/Submitty#10439

When the cursor is over the bad status cell this is the hover text that appears: 
![Image 7-1-24 at 3 55 PM](https://github.com/Submitty/RainbowGrades/assets/105466628/a4cf5eb1-e036-4806-817e-c246fee9f424)
