### PR TITLE
[Bugfix:RainbowGrades] Add omit-dir-time flag to Make command

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -55,10 +55,10 @@ local_push:
 
 pull_test:
 	mkdir -p raw_data/
-	rsync -azPq ${REPORTS_DIRECTORY}/ raw_data/
+	rsync -azPOq ${REPORTS_DIRECTORY}/ raw_data/
 
 push_test:
-	rsync -azPq individual_summary_html/* ${REPORTS_DIRECTORY}/summary_html/
+	rsync -azPOq individual_summary_html/* ${REPORTS_DIRECTORY}/summary_html/
 
 flags = -g
 memory_debug : memory_flags = -m32


### PR DESCRIPTION
rsync: [generator] failed to set times on "/var/local/submitty/courses/s24/sample/rainbow_grades/raw_data/seating": Oper\ ation not permitted (1)

Above error sometimes occur when user runs rainbowgrades from terminal and gui.
According to [stackoverflow](https://stackoverflow.com/a/668049) it can be fixed by
adding `-O` / `--omit-dir-times` to command line which will avoid trying to set modification times on directories.
