### PR TITLE
[Feature:RainbowGrades] Added Sticky Columns to Gradebook

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -568,6 +568,13 @@ void start_table_output( bool /*for_instructor*/,
   // =====================================================================================================
   // DEFINE HEADER ROW
   int counter = 0;
+  student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","USERNAME").MakeSticky());
+  student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","NUMERIC ID").MakeSticky());
+  int last_name_counter=counter;
+  table.set(0,counter++,TableCell("ffffff","FAMILY").MakeSticky());
+  student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","GIVEN").MakeSticky());
+  student_data.push_back(last_name_counter);
+  student_data.push_back(counter);  table.set(0,counter++,TableCell(grey_divider).MakeSticky());
   table.set(0,counter++,TableCell("ffffff","#"));
   table.set(0,counter++,TableCell("ffffff","SECTION"));
   table.set(0,counter++,TableCell("ffffff","reg type"));
@@ -576,16 +583,10 @@ void start_table_output( bool /*for_instructor*/,
     table.set(0,counter++,TableCell("ffffff","under."));
     table.set(0,counter++,TableCell("ffffff","notes"));
   }
-  student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","USERNAME"));
-  student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","NUMERIC ID"));
   if (DISPLAY_INSTRUCTOR_NOTES || DISPLAY_FINAL_GRADE) {
     table.set(0,counter++,TableCell("ffffff","FAMILY (LEGAL)"));
     table.set(0,counter++,TableCell("ffffff","GIVEN (LEGAL)"));
   }
-  int last_name_counter=counter;
-  table.set(0,counter++,TableCell("ffffff","FAMILY"));
-  student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","GIVEN"));
-  student_data.push_back(last_name_counter);
   student_data.push_back(counter);  table.set(0,counter++,TableCell(grey_divider));
 
   if (DISPLAY_EXAM_SEATING) {
@@ -719,9 +720,16 @@ void start_table_output( bool /*for_instructor*/,
     Student *this_student = students[stu];
     
     std::string default_color="ffffff";
-
     myrow++;
     counter = 0;
+
+    assert (default_color.size()==6);
+    table.set(myrow,counter++,TableCell(default_color,this_student->getUserName()).MakeSticky());
+    table.set(myrow,counter++,TableCell(default_color,this_student->getNumericID()).MakeSticky());
+    table.set(myrow,counter++,TableCell(default_color,this_student->getPreferredLastName()).MakeSticky());
+    table.set(myrow,counter++,TableCell(default_color,this_student->getPreferredFirstName()).MakeSticky());
+    table.set(myrow,counter++,TableCell(grey_divider).MakeSticky());
+
     if (this_student->getLastName() == "") {
       if (this_student == sp) {
         default_color= coloritcolor(5,5,4,3,2,1);
@@ -851,15 +859,10 @@ void start_table_output( bool /*for_instructor*/,
     }
 
     //counter+=3;
-    assert (default_color.size()==6);
-    table.set(myrow,counter++,TableCell(default_color,this_student->getUserName()));
-    table.set(myrow,counter++,TableCell(default_color,this_student->getNumericID()));
     if (DISPLAY_INSTRUCTOR_NOTES || DISPLAY_FINAL_GRADE) {
       table.set(myrow,counter++,TableCell(default_color,this_student->getLastName()));
       table.set(myrow,counter++,TableCell(default_color,this_student->getFirstName()));
     }
-    table.set(myrow,counter++,TableCell(default_color,this_student->getPreferredLastName()));
-    table.set(myrow,counter++,TableCell(default_color,this_student->getPreferredFirstName()));
     table.set(myrow,counter++,TableCell(grey_divider));
 
 
@@ -1134,7 +1137,7 @@ void start_table_output( bool /*for_instructor*/,
       std::ofstream ostr_html(OUTPUT_FILE);
 
       GLOBAL_instructor_output = true;
-      table.output(ostr_html, all_students, instructor_data, csv_mode);
+      table.output(ostr_html, all_students, instructor_data, csv_mode, false, true);
 
       end_table(ostr_html, true, NULL);
       ostr_html.close();
@@ -1180,7 +1183,7 @@ void start_table_output( bool /*for_instructor*/,
     }
     GLOBAL_instructor_output = false;
 
-    table.output(ostr3, select_students,student_data, false,true,true,last_update);
+    table.output(ostr3, select_students,student_data, false,true,false,true,last_update);
 
     end_table(ostr3,false,s);
   }

--- a/output.cpp
+++ b/output.cpp
@@ -569,12 +569,12 @@ void start_table_output( bool /*for_instructor*/,
   // DEFINE HEADER ROW
   int counter = 0;
   student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","USERNAME").MakeSticky());
-  student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","NUMERIC ID").MakeSticky());
   int last_name_counter=counter;
   table.set(0,counter++,TableCell("ffffff","FAMILY").MakeSticky());
   student_data.push_back(counter);  table.set(0,counter++,TableCell("ffffff","GIVEN").MakeSticky());
   student_data.push_back(last_name_counter);
   student_data.push_back(counter);  table.set(0,counter++,TableCell(grey_divider).MakeSticky());
+  student_data.push_back(counter); table.set(0,counter++,TableCell("ffffff","NUMERIC ID"));
   table.set(0,counter++,TableCell("ffffff","#"));
   table.set(0,counter++,TableCell("ffffff","SECTION"));
   table.set(0,counter++,TableCell("ffffff","reg type"));
@@ -725,11 +725,11 @@ void start_table_output( bool /*for_instructor*/,
 
     assert (default_color.size()==6);
     table.set(myrow,counter++,TableCell(default_color,this_student->getUserName()).MakeSticky());
-    table.set(myrow,counter++,TableCell(default_color,this_student->getNumericID()).MakeSticky());
     table.set(myrow,counter++,TableCell(default_color,this_student->getPreferredLastName()).MakeSticky());
     table.set(myrow,counter++,TableCell(default_color,this_student->getPreferredFirstName()).MakeSticky());
     table.set(myrow,counter++,TableCell(grey_divider).MakeSticky());
 
+    table.set(myrow,counter++,TableCell(default_color,this_student->getNumericID()));
     if (this_student->getLastName() == "") {
       if (this_student == sp) {
         default_color= coloritcolor(5,5,4,3,2,1);

--- a/table.cpp
+++ b/table.cpp
@@ -144,6 +144,7 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
     
     std::string outline = "";
     std::string mark = "";
+    std::string stick = "";
     if (c.academic_integrity){
         outline = "outline:4px solid #0a0a0a; outline-offset: -4px;";
         mark = "@";
@@ -161,10 +162,20 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         outline = "outline:4px solid #fc0303; outline-offset: -4px;";
     }
 
+    if (c.sticky) {
+      if (c.data == "") {
+        stick = "class=\"sticky-col-boundry\" ";
+      } else {
+        stick = "class=\"sticky-col\" ";
+      }
+    }
+
+    
+
     if (c.extension || c.bad_status) {
-        ostr << "<td " << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "\" align=\"" << c.align << "\">";
+        ostr << "<td " << stick << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "--col-num: " << c.col_num << ";\" align=\"" << c.align << "\">";
     } else {
-        ostr << "<td style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "\" align=\"" << c.align << "\">";
+        ostr << "<td " << stick << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "--col-num: " << c.col_num << ";\" align=\"" << c.align << "\">";
     }
 
   if (0) { //rotate == 90) {
@@ -241,6 +252,7 @@ void Table::output(std::ostream& ostr,
                    std::vector<int> which_data,
                    bool csv_mode,
                    bool transpose,
+                   bool sticky_cells,
                    bool show_details,
                    std::string last_update) const {
 
@@ -279,6 +291,9 @@ void Table::output(std::ostream& ostr,
       ostr << ".hoverable-cell {";
       ostr << "    position: relative;";
       ostr << "}";
+      ostr << "table {";
+      ostr << "    border-collapse: separate;";
+      ostr << "}";
       ostr << ".hoverable-cell:hover::before {";
       ostr << "    content: attr(data-hover-text);";
       ostr << "    position: absolute;";
@@ -296,6 +311,33 @@ void Table::output(std::ostream& ostr,
       ostr << "    justify-content: left;";
       ostr << "    box-sizing: border-box;";
       ostr << "}";
+      ostr << ":root {";
+      ostr << "    --sticky-col-width: 65px;";
+      ostr << "}";
+      if (sticky_cells) {
+        ostr << ".sticky-col, ";
+        ostr << ".sticky-col-boundry {";
+        ostr << "    position: sticky;";
+        ostr << "    z-index: 2;";
+        ostr << "    border-top: 1px solid #aaa;";
+        ostr << "    border-bottom: 1px solid #aaa;";
+        ostr << "    overflow: hidden;";
+        ostr << "    white-space: nowrap;";
+        ostr << "    text-overflow: ellipsis;";
+        ostr << "    left: calc(var(--col-num) * var(--sticky-col-width));";
+        ostr << "}";
+        ostr << ".sticky-col {";
+        ostr << "    width: var(--sticky-col-width);";
+        ostr << "    min-width: var(--sticky-col-width);";
+        ostr << "    max-width: var(--sticky-col-width);";
+        ostr << "    border-left: 1px solid #aaa;";
+        ostr << "    border-right: 1px solid #aaa;";
+        ostr << "}";
+        ostr << ".sticky-col-boundry {";
+        ostr << "    border-left: 2px solid #aaa;";
+        ostr << "    border-right: 2px solid #aaa;";
+        ostr << "}";
+      }
       ostr << "</style>";
 
 

--- a/table.cpp
+++ b/table.cpp
@@ -162,11 +162,23 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
         outline = "outline:4px solid #fc0303; outline-offset: -4px;";
     }
 
-    if (c.sticky) {
-      if (c.data == "") {
-        stick = "class=\"sticky-col-boundry\" ";
+    if (c.sticky_row) {
+      if (c.sticky_col) {
+        if (c.data == "") {
+          stick = "class=\"sticky-corner sticky-col-boundry sticky-row\" ";
+        } else {
+          stick = "class=\"sticky-corner sticky-col sticky-row\" ";
+        }
       } else {
-        stick = "class=\"sticky-col\" ";
+        stick = "class=\"sticky-row\"";
+      }
+    } else {
+      if (c.sticky_col) {
+        if (c.data == "") {
+          stick = "class=\"sticky-col-boundry\" ";
+        } else {
+          stick = "class=\"sticky-col\" ";
+        }
       }
     }
 
@@ -336,6 +348,18 @@ void Table::output(std::ostream& ostr,
         ostr << ".sticky-col-boundry {";
         ostr << "    border-left: 2px solid #aaa;";
         ostr << "    border-right: 2px solid #aaa;";
+        ostr << "}";
+        ostr << ".sticky-row {";
+        ostr << "    position: sticky;";
+        ostr << "    z-index: 2;";
+        ostr << "    top: 0;";
+        ostr << "    border-top: 2px solid #aaa;";
+        ostr << "    border-bottom: 2px solid #aaa;";
+        ostr << "    border-left: 1px solid #aaa;";
+        ostr << "    border-right: 1px solid #aaa;";
+        ostr << "}";
+        ostr << ".sticky-corner {";
+        ostr << "    z-index: 3;";
         ostr << "}";
       }
       ostr << "</style>";

--- a/table.h
+++ b/table.h
@@ -49,10 +49,13 @@ public:
   const std::string& getNote() const { return note; }
   bool ShowNoteToStudent() const { return show_note_to_student; }
   bool ShowNoteToInstructor() const { return show_note_to_instructor; }
+  TableCell& MakeSticky() { sticky = true; return *this; }
   void SetNoteVisibility(bool s, bool i) {
     show_note_to_student = s;
     show_note_to_instructor = i;
   }
+  bool sticky = false;
+  int col_num;
 private:
   std::string note;
   bool show_note_to_student;
@@ -70,6 +73,8 @@ public:
   }
 
   void set(int r, int c, TableCell cell) {
+    cell.col_num = c;
+
     while(r >= numRows()) {
       cells.push_back(std::vector<TableCell>(numCols()));
     }
@@ -86,6 +91,7 @@ public:
               std::vector<int> which_data,
               bool csv_mode=false,
               bool transpose=false,
+              bool sticky_cells=false,
               bool show_details=false,
               std::string last_update="") const;
   

--- a/table.h
+++ b/table.h
@@ -49,12 +49,13 @@ public:
   const std::string& getNote() const { return note; }
   bool ShowNoteToStudent() const { return show_note_to_student; }
   bool ShowNoteToInstructor() const { return show_note_to_instructor; }
-  TableCell& MakeSticky() { sticky = true; return *this; }
+  TableCell& MakeSticky() { sticky_col = true; return *this; }
   void SetNoteVisibility(bool s, bool i) {
     show_note_to_student = s;
     show_note_to_instructor = i;
   }
-  bool sticky = false;
+  bool sticky_col = false;
+  bool sticky_row = false;
   int col_num;
 private:
   std::string note;
@@ -74,6 +75,7 @@ public:
 
   void set(int r, int c, TableCell cell) {
     cell.col_num = c;
+    if (r == 0) cell.sticky_row = true;
 
     while(r >= numRows()) {
       cells.push_back(std::vector<TableCell>(numCols()));


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->
### Why is this Change Important & Necessary?
Partially addresses [Issue #10273 In Submitty/Submitty](https://github.com/Submitty/Submitty/issues/10273)

### What is the New Behavior?
The leftmost 4 rows, which contain the User ID, Numeric ID, First Name, & Last Name, stay in place when scrolling to the right.

Before:

https://github.com/user-attachments/assets/35260e4f-8a84-482f-b9b5-422e95516b5a


After:

https://github.com/user-attachments/assets/3d761ea3-1ab3-4047-a671-09c0b81219fd

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. As an instructor, visit the grades configuration tab and rebuild the rainbow grades. 
2. Visit the gradebook page and try scrolling the table of grades left and right.
3. Observe the new behavior or sticky columns.

Edit: Since multiple people noted issues with testing this PR due to the changes existing in two different repositories, here are instructions for setting up Submitty to read the changes in the RainbowGrades repository.

1. run `git clone https://github.com/Submitty/RainbowGrades.git` in the directory above Submitty. The resulting file structure should look like: 
```
RCOS_Submitty/ (or some other name)
├─ Submitty/
│  ├─ site/
│  ├─ grading/
│  ├─ bin/
│  ├─ ...
├─ RainbowGrades/
│  ├─ student.cpp
│  ├─ table.cpp
│  ├─ output.cpp
│  ├─ ...
├─ ...
```
2. in the RainbowGrades folder, run `git checkout sticky-columns`
3. in the Submitty folder, run `git checkout gradebook-format-fix`
4. in the Submitty folder, run `vagrant halt`, then `vagrant up`, to link the RainbowGrades folder to the VM. If this worked correctly you should see the line
 `ubuntu-22.04: /home/username_example/RCOS_Submitty/RainbowGrades => /usr/local/submitty/GIT_CHECKOUT/RainbowGrades`
5. run `vagrant ssh`, the run `submitty_install`, to fetch re-compile rainbow grades.
6. follow the build and test instructions listed above.

### Automated Testing & Documentation
No testing or documentation is needed, as the change is purely visual.

### Other information
Due to a small styling issue, I had to make a 1-line PR in the Submitty/Submitty repository, which can be found [here](https://github.com/Submitty/Submitty/pull/12754). Reviewers should review both PR's simultaneously.