### PR TITLE
[Feature:RainbowGrades] Adding link to gradeables

### DIFF
--- a/SAMPLE_Makefile
+++ b/SAMPLE_Makefile
@@ -4,8 +4,7 @@
 USERNAME=username
 RAINBOW_GRADES_DIRECTORY=/<PATH_TO_SUBMITTY_REPO>/RainbowGrades
 HWSERVER=submitty.cs.rpi.edu
-REPORTS_DIRECTORY=/var/local/submitty/courses/<SEMESTER>/<COURSE>/reports
-
+export REPORTS_DIRECTORY=/var/local/submitty/courses/<SEMESTER>/<COURSE>/reports
 # =============================================================================
 
 include ${RAINBOW_GRADES_DIRECTORY}/MakefileHelper

--- a/output.cpp
+++ b/output.cpp
@@ -141,8 +141,11 @@ int convertMajor(const std::string &major) {
 // ==========================================================
 
 std::vector<string> getCourseDetails() {
-  std::vector<string> courseDetails;
+  std::vector<std::string> courseDetails;
   std::ifstream i("/var/local/submitty/courses/f24/sample/reports/base_url.json");
+  if(!i){
+    return {}
+  }
   nlohmann::json j;
   i >> j;
   courseDetails[0] = j["base_url"].get<std::string>();
@@ -651,11 +654,13 @@ void start_table_output( bool /*for_instructor*/,
         }
 
         std::vector<string> courseDetails = getCourseDetails();
-        std::string base_url = courseDetails[0];
-        std::string semester = courseDetails[1];
-        std::string course = courseDetails[2];
+        if(courseDetails.size() == 3){
+          std::string base_url = courseDetails[0];
+          std::string semester = courseDetails[1];
+          std::string course = courseDetails[2];
 
-        std::string fullURL = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
+          std::string fullURL = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
+        }
 
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";

--- a/output.cpp
+++ b/output.cpp
@@ -155,6 +155,40 @@ std::tuple<std::string, std::string, std::string> getCourseDetails() {
   return {baseUrl, term, course};
 }
 
+std::string getGradeableType(const std::string &firstUserName, const std::string &gradeableID) {
+    const char* reportsDir = std::getenv("REPORTS_DIRECTORY");
+
+    std::string path = std::string(reportsDir) + "/../rainbow_grades/raw_data/all_grades/" + firstUserName + "_summary.json";
+    std::ifstream i(path);
+
+    nlohmann::json j;
+    i >> j;
+
+    std::string gradeableType = "";
+
+    for (auto it = j.begin(); it != j.end(); ++it) {
+      if (!it.value().is_array()) {
+        continue;
+      }
+
+      for (const auto& item : it.value()) {
+        if (item.contains("id") && item["id"].is_string() && 
+          item["id"].get<std::string>() == gradeableID) {
+          if (item.contains("gradeable_type") && item["gradeable_type"].is_string()) {
+            gradeableType = item["gradeable_type"].get<std::string>();
+            break;
+          }
+        }
+      }
+
+      if (!gradeableType.empty()) {
+        break;
+      }
+    }
+
+  return gradeableType;
+}
+
 class Color {
 public:
   Color(int r_=0, int g_=0, int b_=0) : r(r_),g(g_),b(b_) {}
@@ -647,6 +681,17 @@ void start_table_output( bool /*for_instructor*/,
   // ----------------------------
   // DETAILS OF EACH GRADEABLE
   if (DISPLAY_GRADE_DETAILS) {
+    std::string firstUserName = "";
+    for(unsigned int stu = 0; stu < students.size(); stu++){
+      Student *this_student = students[stu];
+      if(this_student->getUserName() == "AVERAGE" || this_student->getUserName() == "STDDEV"){
+        continue;
+      }
+      else{
+        firstUserName = this_student->getUserName();
+        break;
+      }
+    }
     for (unsigned int i = 0; i < ALL_GRADEABLES.size(); i++) {
       GRADEABLE_ENUM g = ALL_GRADEABLES[i];
       for (int j = 0; j < GRADEABLES[g].getCount(); j++) {
@@ -662,11 +707,12 @@ void start_table_output( bool /*for_instructor*/,
         std::string course = std::get<2>(courseDetails);
         std::string fullUrl = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
 
+        std::string gradeableType = getGradeableType(firstUserName, gradeable_id);
+
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
           bool checkReleased = GRADEABLES[g].isReleased(gradeable_id);
-          if(checkReleased){
-            // g != GRADEABLE_ENUM::LAB ...
+          if(checkReleased && gradeableType == "Electronic File"){
             gradeable_name = gradeable_name + " <i class='fa-solid fa-arrow-up-right-from-square' style='color:blue;'></i>";
             gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black; text-decoration:none;\" title=\"View Gradeable\">" + gradeable_name + "</a>";
           }

--- a/output.cpp
+++ b/output.cpp
@@ -663,9 +663,13 @@ void start_table_output( bool /*for_instructor*/,
         std::string fullUrl = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
-          gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;            
-          gradeable_name = gradeable_name + " <i class='fa-solid fa-arrow-up-right-from-square' style='color:blue;'></i>";
-          gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black; text-decoration:none;\" title=\"View Gradeable\">" + gradeable_name + "</a>";
+          gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
+          bool checkReleased = GRADEABLES[g].isReleased(gradeable_id);
+          if(checkReleased){
+            // g != GRADEABLE_ENUM::LAB ...
+            gradeable_name = gradeable_name + " <i class='fa-solid fa-arrow-up-right-from-square' style='color:blue;'></i>";
+            gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black; text-decoration:none;\" title=\"View Gradeable\">" + gradeable_name + "</a>";
+          }
         }
 
         if (gradeable_name == "")

--- a/output.cpp
+++ b/output.cpp
@@ -663,8 +663,9 @@ void start_table_output( bool /*for_instructor*/,
         std::string fullUrl = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
-          gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
-          gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
+          gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;            
+          gradeable_name = gradeable_name + " <i class='fa-solid fa-arrow-up-right-from-square' style='color:blue;'></i>";
+          gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black; text-decoration:none;\" title=\"View Gradeable\">" + gradeable_name + "</a>";
         }
 
         if (gradeable_name == "")

--- a/output.cpp
+++ b/output.cpp
@@ -664,7 +664,6 @@ void start_table_output( bool /*for_instructor*/,
 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
-          // gradeable_name = spacify(gradeable_name);
           gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }
 

--- a/output.cpp
+++ b/output.cpp
@@ -140,6 +140,17 @@ int convertMajor(const std::string &major) {
 
 // ==========================================================
 
+std::vector<string> getCourseDetails() {
+  std::vector<string> courseDetails;
+  std::ifstream i("/var/local/submitty/courses/f24/sample/reports/base_url.json");
+  nlohmann::json j;
+  i >> j;
+  courseDetails[0] = j["base_url"].get<std::string>();
+  courseDetails[1] = j["term"].get<std::string>();;
+  courseDetails[2] = j["course"].get<std::string>();;
+  return courseDetails;
+}
+
 class Color {
 public:
   Color(int r_=0, int g_=0, int b_=0) : r(r_),g(g_),b(b_) {}
@@ -638,11 +649,20 @@ void start_table_output( bool /*for_instructor*/,
         if (g != GRADEABLE_ENUM::NOTE) {
           student_data.push_back(counter);
         }
+
+        std::vector<string> courseDetails = getCourseDetails();
+        std::string base_url = courseDetails[0];
+        std::string semester = courseDetails[1];
+        std::string course = courseDetails[2];
+
+        std::string fullURL = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
+
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
           //gradeable_name = spacify(gradeable_name);
+          gradeable_name = "<a href=\"" + fullURL + "\"" gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }
         if (gradeable_name == "")
           gradeable_name = "<em><font color=\"aaaaaa\">future "


### PR DESCRIPTION
Closes [#10433](https://github.com/Submitty/Submitty/issues/10433)

Credit to @oliiso and @ryvaru for doing most of the work on this issue on [PR#81](https://github.com/Submitty/RainbowGrades/pull/81) and [PR#83](https://github.com/Submitty/RainbowGrades/pull/83)

**What is the current behavior?**
Currently, students can only see their grade for a specific gradeable on Rainbow Grades, and would have to search through gradeables to see their full report.

**What is the new behavior?**
Now, when students see their grade on Rainbow Grades, they can just click on it and it sends them to see their full report directly. This is more convenient and helpful for students. Note that for a gradeable to have a link, the gradeable must be released AND its type must be an Electronic File Upload, nothing else will work.

