### PR TITLE
[Feature:RainbowGrades] Link to gradeable

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -646,7 +646,7 @@ void start_table_output( bool /*for_instructor*/,
           //gradeable_name = spacify(gradeable_name);
           gradeable_name = "<a href=\"" + gradeable_url + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }
-        if (gradeable_name == "") {
+        if (gradeable_name == "")
           gradeable_name = "<em><font color=\"aaaaaa\">future "
             + tolower(gradeable_to_string(g)) + "</font></em>";
         table.set(0,counter++,TableCell("ffffff",gradeable_name));

--- a/output.cpp
+++ b/output.cpp
@@ -640,9 +640,11 @@ void start_table_output( bool /*for_instructor*/,
         }
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";
+        std::string gradeable_url = "https://submitty.org/grading_details/" + gradeable_id; 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
           //gradeable_name = spacify(gradeable_name);
+          gradeable_name = "<a href=\"" + gradeable_url + "\">" + gradeable_name + "</a>";
         }
         if (gradeable_name == "")
           gradeable_name = "<em><font color=\"aaaaaa\">future "

--- a/output.cpp
+++ b/output.cpp
@@ -644,7 +644,7 @@ void start_table_output( bool /*for_instructor*/,
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
           //gradeable_name = spacify(gradeable_name);
-          gradeable_name = "<a href=\"" + gradeable_url + "\">" + gradeable_name + "</a>";
+          gradeable_name = "<a href=\"" + gradeable_url + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }
         if (gradeable_name == "") {
           gradeable_name = "<em><font color=\"aaaaaa\">future "

--- a/output.cpp
+++ b/output.cpp
@@ -138,11 +138,14 @@ int convertMajor(const std::string &major) {
   else return 10;
 }
 
-std::string getBaseUrl() {
+std::tuple<std::string, std::string, std::string> getCourseDetails() {
     std::ifstream i("/var/local/submitty/courses/f24/sample/reports/base_url.json");
     nlohmann::json j;
     i >> j;
-    return j["base_url"].get<std::string>();
+    std::string baseUrl = j["base_url"].get<std::string>();
+    std::string term = j["term"].get<std::string>();
+    std::string course = j["course"].get<std::string>();
+    return {baseUrl, term, course};
 }
 
 // ==========================================================
@@ -645,12 +648,10 @@ void start_table_output( bool /*for_instructor*/,
         if (g != GRADEABLE_ENUM::NOTE) {
           student_data.push_back(counter);
         }
+        auto [base_url, semester, course] = getCourseDetails();
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";
-        std::string base_url = getBaseUrl();
-        std::string semester = "f24/";
-        std::string course = "sample";
-        std::string fullUrl = base_url + "courses/" + semester + course + "/gradeable/" + gradeable_id;
+        std::string fullUrl = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;

--- a/output.cpp
+++ b/output.cpp
@@ -138,6 +138,13 @@ int convertMajor(const std::string &major) {
   else return 10;
 }
 
+std::string getBaseUrl() {
+    std::ifstream i("/var/local/submitty/courses/f24/sample/reports/base_url.json");
+    nlohmann::json j;
+    i >> j;
+    return j["base_url"].get<std::string>();
+}
+
 // ==========================================================
 
 class Color {
@@ -632,6 +639,7 @@ void start_table_output( bool /*for_instructor*/,
   // ----------------------------
   // DETAILS OF EACH GRADEABLE
   if (DISPLAY_GRADE_DETAILS) {
+    Student* this_student = new Student();
     for (unsigned int i = 0; i < ALL_GRADEABLES.size(); i++) {
       GRADEABLE_ENUM g = ALL_GRADEABLES[i];
       for (int j = 0; j < GRADEABLES[g].getCount(); j++) {
@@ -640,11 +648,16 @@ void start_table_output( bool /*for_instructor*/,
         }
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";
-        std::string gradeable_url = "https://submitty.org/grading_details/" + gradeable_id; 
+        std::string section = "";
+        std::string base_url = getBaseUrl();
+        std::string gradeable_url = base_url + gradeable_id;
+        std::string fullUrl = base_url + "/" + section + "/gradeable/" + gradeable_id;
+
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
+          section = this_student->getSection();
           //gradeable_name = spacify(gradeable_name);
-          gradeable_name = "<a href=\"" + gradeable_url + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
+          gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }
         if (gradeable_name == "")
           gradeable_name = "<em><font color=\"aaaaaa\">future "

--- a/output.cpp
+++ b/output.cpp
@@ -639,7 +639,6 @@ void start_table_output( bool /*for_instructor*/,
   // ----------------------------
   // DETAILS OF EACH GRADEABLE
   if (DISPLAY_GRADE_DETAILS) {
-    Student* this_student = new Student();
     for (unsigned int i = 0; i < ALL_GRADEABLES.size(); i++) {
       GRADEABLE_ENUM g = ALL_GRADEABLES[i];
       for (int j = 0; j < GRADEABLES[g].getCount(); j++) {
@@ -648,14 +647,13 @@ void start_table_output( bool /*for_instructor*/,
         }
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";
-        std::string section = "";
         std::string base_url = getBaseUrl();
-        std::string gradeable_url = base_url + gradeable_id;
-        std::string fullUrl = base_url + "/" + section + "/gradeable/" + gradeable_id;
+        std::string semester = "f24/";
+        std::string course = "sample";
+        std::string fullUrl = base_url + "courses/" + semester + course + "/gradeable/" + gradeable_id;
 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
-          section = this_student->getSection();
           //gradeable_name = spacify(gradeable_name);
           gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }

--- a/output.cpp
+++ b/output.cpp
@@ -646,7 +646,7 @@ void start_table_output( bool /*for_instructor*/,
           //gradeable_name = spacify(gradeable_name);
           gradeable_name = "<a href=\"" + gradeable_url + "\">" + gradeable_name + "</a>";
         }
-        if (gradeable_name == "")
+        if (gradeable_name == "") {
           gradeable_name = "<em><font color=\"aaaaaa\">future "
             + tolower(gradeable_to_string(g)) + "</font></em>";
         table.set(0,counter++,TableCell("ffffff",gradeable_name));

--- a/output.cpp
+++ b/output.cpp
@@ -143,16 +143,17 @@ std::tuple<std::string, std::string, std::string> getCourseDetails() {
     std::ifstream i("./raw_data/base_url.json");
     nlohmann::json j;
     i >> j;
+    assert (j.find("base_url") != j.end());
     std::string baseUrl = j["base_url"].get<std::string>();
+    assert (j.find("term") != j.end());
     std::string term = j["term"].get<std::string>();
+    assert (j.find("course") != j.end());
     std::string course = j["course"].get<std::string>();
     return {baseUrl, term, course};
 }
 
 std::string getGradeableType(const std::string &firstUserName, const std::string &gradeableID) {
-    // std::string path = "./raw_data/all_grades/" + firstUserName + "_summary.json";
     std::ifstream i( ("./raw_data/all_grades/" + firstUserName + "_summary.json") );
-
     nlohmann::json j;
     i >> j;
 
@@ -162,7 +163,6 @@ std::string getGradeableType(const std::string &firstUserName, const std::string
       if (!it.value().is_array()) {
         continue;
       }
-
       for (const auto& item : it.value()) {
         if (item.contains("id") && item["id"].is_string() && 
           item["id"].get<std::string>() == gradeableID) {
@@ -680,10 +680,8 @@ void start_table_output( bool /*for_instructor*/,
     std::string firstUserName = "";
     for(unsigned int stu = 0; stu < students.size(); stu++){
       Student *this_student = students[stu];
-      if(this_student->getUserName() == "AVERAGE" || this_student->getUserName() == "STDDEV"){
-        continue;
-      }
-      else{
+      if (!validSection(this_student->getSection())) continue;
+      else {
         firstUserName = this_student->getUserName();
         break;
       }

--- a/output.cpp
+++ b/output.cpp
@@ -149,6 +149,38 @@ std::tuple<std::string, std::string, std::string> getCourseDetails() {
     return {baseUrl, term, course};
 }
 
+std::string getGradeableType(const std::string &firstUserName, const std::string &gradeableID) {
+    // std::string path = "./raw_data/all_grades/" + firstUserName + "_summary.json";
+    std::ifstream i( ("./raw_data/all_grades/" + firstUserName + "_summary.json") );
+
+    nlohmann::json j;
+    i >> j;
+
+    std::string gradeableType = "";
+
+    for (auto it = j.begin(); it != j.end(); ++it) {
+      if (!it.value().is_array()) {
+        continue;
+      }
+
+      for (const auto& item : it.value()) {
+        if (item.contains("id") && item["id"].is_string() && 
+          item["id"].get<std::string>() == gradeableID) {
+          if (item.contains("gradeable_type") && item["gradeable_type"].is_string()) {
+            gradeableType = item["gradeable_type"].get<std::string>();
+            break;
+          }
+        }
+      }
+
+      if (!gradeableType.empty()) {
+        break;
+      }
+    }
+
+  return gradeableType;
+}
+
 // ==========================================================
 
 class Color {
@@ -645,19 +677,43 @@ void start_table_output( bool /*for_instructor*/,
   // ----------------------------
   // DETAILS OF EACH GRADEABLE
   if (DISPLAY_GRADE_DETAILS) {
+    std::string firstUserName = "";
+    for(unsigned int stu = 0; stu < students.size(); stu++){
+      Student *this_student = students[stu];
+      if(this_student->getUserName() == "AVERAGE" || this_student->getUserName() == "STDDEV"){
+        continue;
+      }
+      else{
+        firstUserName = this_student->getUserName();
+        break;
+      }
+    }
+
     for (unsigned int i = 0; i < ALL_GRADEABLES.size(); i++) {
       GRADEABLE_ENUM g = ALL_GRADEABLES[i];
       for (int j = 0; j < GRADEABLES[g].getCount(); j++) {
         if (g != GRADEABLE_ENUM::NOTE) {
           student_data.push_back(counter);
         }
-        auto [base_url, semester, course] = getCourseDetails();
+
         std::string gradeable_id = GRADEABLES[g].getID(j);
         std::string gradeable_name = "";
+
+        auto courseDetails = getCourseDetails();
+        std::string base_url = std::get<0>(courseDetails);
+        std::string semester = std::get<1>(courseDetails);
+        std::string course = std::get<2>(courseDetails);
         std::string fullUrl = base_url + "courses/" + semester + "/" + course + "/gradeable/" + gradeable_id;
+
+        std::string gradeableType = getGradeableType(firstUserName, gradeable_id);
 
         if (GRADEABLES[g].hasCorrespondence(gradeable_id)) {
           gradeable_name = GRADEABLES[g].getCorrespondence(gradeable_id).second;
+          bool checkReleased = GRADEABLES[g].isReleased(gradeable_id);
+          if(checkReleased && gradeableType == "Electronic File"){
+            gradeable_name = gradeable_name + " <i class='fa-solid fa-arrow-up-right-from-square' style='color:blue;'></i>";
+            gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black; text-decoration:none;\" title=\"View Gradeable\">" + gradeable_name + "</a>";
+          }
           //gradeable_name = spacify(gradeable_name);
           gradeable_name = "<a href=\"" + fullUrl + "\" style=\"color:black;\">" + gradeable_name + "&nbsp;&nbsp; <i class='fas fa-external-link-alt'></i></a>";
         }

--- a/output.cpp
+++ b/output.cpp
@@ -139,7 +139,7 @@ int convertMajor(const std::string &major) {
 }
 
 std::tuple<std::string, std::string, std::string> getCourseDetails() {
-    std::ifstream i("/var/local/submitty/courses/f24/sample/reports/base_url.json");
+    std::ifstream i("./raw_data/base_url.json");
     nlohmann::json j;
     i >> j;
     std::string baseUrl = j["base_url"].get<std::string>();


### PR DESCRIPTION
Closes https://github.com/Submitty/Submitty/issues/10433

Credit to @oliiso and @ryvaru for doing most of the work on this issue on https://github.com/Submitty/RainbowGrades/pull/81 and https://github.com/Submitty/RainbowGrades/pull/83

What is the current behavior?
Currently, students can only see their grade for a specific gradeable on Rainbow Grades, and would have to search through gradeables to see their full report.

What is the new behavior?
Now, when students see their grade on Rainbow Grades, they can just click on it and it sends them to see their full report directly. This is more convenient and helpful for students. Note that for a gradeable to have a link, the gradeable must be released AND its type must be an Electronic File Upload, nothing else will work. 

This version should work with manual setup as well as the automatic setup. 

<img width="810" height="1358" alt="image" src="https://github.com/user-attachments/assets/e7feac9c-b993-4f02-87fd-bf24e3578b03" />
