### PR TITLE
[Bugfix:RainbowGrades] sticky columns expand to fit contents

### DIFF
--- a/table.cpp
+++ b/table.cpp
@@ -333,9 +333,8 @@ void Table::output(std::ostream& ostr,
         ostr << "    z-index: 2;";
         ostr << "    border-top: 1px solid #aaa;";
         ostr << "    border-bottom: 1px solid #aaa;";
-        ostr << "    overflow: hidden;";
-        ostr << "    white-space: nowrap;";
-        ostr << "    text-overflow: ellipsis;";
+        ostr << "    overflow-wrap: break-word;";
+        ostr << "    white-space: normal;";
         ostr << "    left: calc(var(--col-num) * var(--sticky-col-width));";
         ostr << "}";
         ostr << ".sticky-col {";

--- a/table.cpp
+++ b/table.cpp
@@ -361,54 +361,30 @@ void Table::output(std::ostream& ostr,
         ostr << "}";
 
         // Calculate Dynamic Width for Sticky Columns
-        if (!which_students.empty() && !which_data.empty()){
+        if (!which_students.empty() && !which_data.empty()) {
             int current_left_px = 0;
             int col_idx = 1;
-            if (!transpose) {
-                for (int c : which_data) {
-                    int max_len = 0;
-                    bool is_sticky = false;
-                    for (int r : which_students) {
-                        int len = cells[r][c].make_cell_string(false).length();
-                        if (len > max_len) max_len = len;
-                        if (cells[r][c].sticky_col) is_sticky = true;
-                    }
-                    // Approx 8px per char. Minimum 65px.
-                    int col_width = std::max(65, (max_len * 8));
 
-                    ostr << "table tr td:nth-child(" << col_idx << ") {";
-                    ostr << " --this-col-left: " << current_left_px << "px;";
-                    ostr << " --this-col-width: " << col_width << "px;";
-                    ostr << "}";
-
-                    if (is_sticky) {
-                        current_left_px += col_width;
-                    }
-                    col_idx++;
-                }
-            }
-            else {
+            for (int c : which_data) {
+                int max_len = 0;
+                bool is_sticky = false;
                 for (int r : which_students) {
-                    int max_len = 0;
-                    bool is_sticky = false;
-                    for (int c : which_data) {
-                        int len = cells[r][c].make_cell_string(false).length();
-                        if (len > max_len) max_len = len;
-                        if (cells[r][c].sticky_col) is_sticky = true;
-                    }
-                    // Approx 8px per char. Minimum 65px.
-                    int col_width = std::max(65, (max_len * 8));
-
-                    ostr << "table tr td:nth-child(" << col_idx << ") {";
-                    ostr << " --this-col-left: " << current_left_px << "px;";
-                    ostr << " --this-col-width: " << col_width << "px;";
-                    ostr << "}";
-
-                    if (is_sticky) {
-                        current_left_px += col_width;
-                    }
-                    col_idx++;
+                    int len = cells[r][c].make_cell_string(false).length();
+                    if (len > max_len) max_len = len;
+                    if (cells[r][c].sticky_col) is_sticky = true;
                 }
+                // Approx 8px per char. Minimum 65px.
+                int col_width = std::max(65, (max_len * 8));
+
+                ostr << "table tr td:nth-child(" << col_idx << ") {";
+                ostr << " --this-col-left: " << current_left_px << "px;";
+                ostr << " --this-col-width: " << col_width << "px;";
+                ostr << "}";
+
+                if (is_sticky) {
+                    current_left_px += col_width;
+                }
+                col_idx++;
             }
         }
       }

--- a/table.cpp
+++ b/table.cpp
@@ -27,34 +27,34 @@ std::string CSVSanitizeString(const std::string& s){
 }
 
 TableCell::TableCell(const std::string& c, const std::string& d, const std::string& n, int ldu,
-                     CELL_CONTENTS_STATUS v, const std::string& a, int s, int r) { 
+                     CELL_CONTENTS_STATUS v, const std::string& a, int s, int r) {
 
   assert (c.size() == 6);
-  color=c; 
-  data=d; 
+  color=c;
+  data=d;
   note=n;
   show_note_to_student = false;
   show_note_to_instructor = false;
   late_days_used=ldu,
   visible=v;
   align=a;
-  span=s; 
+  span=s;
   rotate=r;
 }
 
 TableCell::TableCell(const std::string& c, int d, const std::string& n, int ldu,
-                     CELL_CONTENTS_STATUS v, const std::string& a, int s, int r) { 
+                     CELL_CONTENTS_STATUS v, const std::string& a, int s, int r) {
 
   assert (c.size() == 6);
-  color=c; 
-  data=std::to_string(d); 
+  color=c;
+  data=std::to_string(d);
   note=n;
   show_note_to_student = false;
   show_note_to_instructor = false;
   late_days_used=ldu,
   visible=v;
   align=a;
-  span=s; 
+  span=s;
   rotate=r;
 }
 
@@ -63,11 +63,11 @@ TableCell::TableCell(const std::string& c, float d, int precision, const std::st
 
   assert (c.size() == 6);
   assert (precision >= 0);
-  color=c; 
+  color=c;
   if (fabs(d) > 0.0001) {
     std::stringstream ss;
     ss << std::setprecision(precision) << std::fixed << d;
-    data=ss.str(); span=s; 
+    data=ss.str(); span=s;
   } else {
     data = "";
   }
@@ -77,12 +77,12 @@ TableCell::TableCell(const std::string& c, float d, int precision, const std::st
   late_days_used=ldu,
   visible=v;
   align=a;
-  span=s; 
+  span=s;
   rotate = 0;
 }
 
 TableCell::TableCell(float d, const std::string& c, int precision, const std::string& n, int ldu,
-                     CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a, 
+                     CELL_CONTENTS_STATUS v,const std::string& e,bool ai, const std::string& a,
                      int s, int /*r*/,const std::string& reason,const std::string& gID,const std::string& userName, int daysExtended) {
 
   assert (c.size() == 6);
@@ -141,7 +141,7 @@ TableCell::TableCell(float d, const std::string& c, int precision, const std::st
 
 std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
   assert (c.color.size() == 6);
-    
+
     std::string outline = "";
     std::string mark = "";
     std::string stick = "";
@@ -182,7 +182,7 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
       }
     }
 
-    
+
 
     if (c.extension || c.bad_status) {
         ostr << "<td " << stick << c.hoverText << "style=\"border:1px solid #aaaaaa; background-color:#" << c.color << "; " << outline << "--col-num: " << c.col_num << ";\" align=\"" << c.align << "\">";
@@ -202,11 +202,11 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
   }
   else if ((c.data == "" && mynote=="")
       || c.visible==CELL_CONTENTS_HIDDEN
-      || (c.visible==CELL_CONTENTS_VISIBLE_INSTRUCTOR && GLOBAL_instructor_output == false) 
+      || (c.visible==CELL_CONTENTS_VISIBLE_INSTRUCTOR && GLOBAL_instructor_output == false)
       || (c.visible==CELL_CONTENTS_VISIBLE_STUDENT    && GLOBAL_instructor_output == true)) {
     ostr << "<div></div>";
   } else {
-    ostr << c.data; 
+    ostr << c.data;
     if (c.late_days_used > 0) {
       if (c.late_days_used > 3) { ostr << " (" << std::to_string(c.late_days_used) << "*)"; }
       else { ostr << " " << std::string(c.late_days_used,'*'); }
@@ -218,7 +218,7 @@ std::ostream& operator<<(std::ostream &ostr, const TableCell &c) {
     if (!global_details) {
       showNote = c.ShowNoteToInstructor();
     }
-    
+
     if (mynote.length() > 0 &&
         mynote != " " &&
         showNote) {
@@ -333,14 +333,13 @@ void Table::output(std::ostream& ostr,
         ostr << "    z-index: 2;";
         ostr << "    border-top: 1px solid #aaa;";
         ostr << "    border-bottom: 1px solid #aaa;";
-        ostr << "    overflow-wrap: break-word;";
-        ostr << "    white-space: normal;";
-        ostr << "    left: calc(var(--col-num) * var(--sticky-col-width));";
+        ostr << "    overflow: hidden;";
+        ostr << "    white-space: nowrap;";
+        ostr << "    left: var(--this-col-left, 0px);";
         ostr << "}";
         ostr << ".sticky-col {";
-        ostr << "    width: var(--sticky-col-width);";
-        ostr << "    min-width: var(--sticky-col-width);";
-        ostr << "    max-width: var(--sticky-col-width);";
+        ostr << "    width: max-content;";
+        ostr << "    min-width: var(--this-col-width, 65px);";
         ostr << "    border-left: 1px solid #aaa;";
         ostr << "    border-right: 1px solid #aaa;";
         ostr << "}";
@@ -360,6 +359,58 @@ void Table::output(std::ostream& ostr,
         ostr << ".sticky-corner {";
         ostr << "    z-index: 3;";
         ostr << "}";
+
+        // Calculate Dynamic Width for Sticky Columns
+        if (!which_students.empty() && !which_data.empty()){
+            int current_left_px = 0;
+            int col_idx = 1;
+            if (!transpose) {
+                for (int c : which_data) {
+                    int max_len = 0;
+                    bool is_sticky = false;
+                    for (int r : which_students) {
+                        int len = cells[r][c].make_cell_string(false).length();
+                        if (len > max_len) max_len = len;
+                        if (cells[r][c].sticky_col) is_sticky = true;
+                    }
+                    // Approx 8px per char. Minimum 65px.
+                    int col_width = std::max(65, (max_len * 8));
+
+                    ostr << "table tr td:nth-child(" << col_idx << ") {";
+                    ostr << " --this-col-left: " << current_left_px << "px;";
+                    ostr << " --this-col-width: " << col_width << "px;";
+                    ostr << "}";
+
+                    if (is_sticky) {
+                        current_left_px += col_width;
+                    }
+                    col_idx++;
+                }
+            }
+            else {
+                for (int r : which_students) {
+                    int max_len = 0;
+                    bool is_sticky = false;
+                    for (int c : which_data) {
+                        int len = cells[r][c].make_cell_string(false).length();
+                        if (len > max_len) max_len = len;
+                        if (cells[r][c].sticky_col) is_sticky = true;
+                    }
+                    // Approx 8px per char. Minimum 65px.
+                    int col_width = std::max(65, (max_len * 8));
+
+                    ostr << "table tr td:nth-child(" << col_idx << ") {";
+                    ostr << " --this-col-left: " << current_left_px << "px;";
+                    ostr << " --this-col-width: " << col_width << "px;";
+                    ostr << "}";
+
+                    if (is_sticky) {
+                        current_left_px += col_width;
+                    }
+                    col_idx++;
+                }
+            }
+        }
       }
       ostr << "</style>";
 
@@ -404,7 +455,7 @@ void Table::output(std::ostream& ostr,
               ostr << "\n";
           }
       }
-  } 
+  }
 
   if(!csv_mode) {
       ostr << "</table>" << std::endl;


### PR DESCRIPTION
**Describe the issue:**

Users could not see contents in the sticky columns if they were too long for the container. Now, the sticky columns are dynamic-width to fit the longest of the contents. 

Before Screenshot: (Observe ellipsis instead of full info in the left side columns)
<img width="1031" height="953" alt="image" src="https://github.com/user-attachments/assets/78b62fb6-99d0-4622-ba0e-0a2e6dbe2546" />

After Screenshot:
<img width="1920" height="951" alt="image" src="https://github.com/user-attachments/assets/e691b69c-b52d-4136-bb4c-2ea3f04feff4" />


An instructor was having an issue with the ellipsis provided in the sticky columns. RainbowGrades has been updated to make the sticky columns wide enough to contain the information without wrapping or truncating.

**What steps should a reviewer take to reproduce the bug or feature?**

0. Set up RainbowGrades on your machine:
run git clone https://github.com/Submitty/RainbowGrades.git in the directory above Submitty. The resulting file structure should look like:

GIT_CHECKOUT/
|-- Submitty/
|-- RainbowGrades/

1. In the RainbowGrades folder, run git checkout column-content-fit
2. In the Submitty folder, run vagrant halt, then vagrant up, to link the RainbowGrades folder to the VM. If this worked correctly you should see the line ubuntu-22.04: /home/username_example/Submitty/GIT_CHECKOUT/RainbowGrades => /usr/local/submitty/GIT_CHECKOUT/RainbowGrades
3. Run submitty_install to see the changes:
- Go to Grades Configuration and rebuild RainbowGrades. You may need to add some display items first from the checkboxes below.
- Go to the Gradebook and observe the sticky column content fits. 
4. You can also check the rainbow_grades output.html file:
- In the VM, cd /var/local/submitty/courses/s26/sample/rainbow_grades
- cp output.html /usr/local/submitty/GIT_CHECKOUT/Submitty
This will put the output.html file in your Submitty directory (above GIT_CHECKOUT) where you can then view the output.html file in your browser. 
