### PR TITLE
[Bugfix:RainbowGrades] Fix exam seating zone bug

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -1,4 +1,4 @@
-.PHONY: default pull push all compile overall section lab hw test quiz final zone clean src_clean remove_json_comments version tables clean_tables
+.PHONY: default pull push all compile overall section lab hw test quiz final zone clean src_clean remove_json_comments version
 
 default: overall
 
@@ -164,16 +164,5 @@ test_exam: compile
 
 zone: compile
 	./process_grades.out by_zone
-
-SORT_ORDERS ?= by_overall by_section by_hw by_lab by_test by_exam
-
-clean_tables:
-	rm -f output.html output.csv output-by-*.html output-by-*.csv
-
-tables: compile clean_tables
-	@for order in $(SORT_ORDERS); do \
-		echo "=== building table: $$order ==="; \
-		./process_grades.out $$order || exit 1; \
-	done
 
 # =============================================================================

--- a/MakefileHelper
+++ b/MakefileHelper
@@ -90,6 +90,7 @@ remove_json_comments: customization.json
 	python3 -m json.tool customization_no_comments.json > /dev/null
 
 process_grades.out: \
+	${nlohmann_json_dir} \
 	${RAINBOW_GRADES_DIRECTORY}/main.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/output.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/table.cpp \

--- a/MakefileHelper
+++ b/MakefileHelper
@@ -90,14 +90,14 @@ remove_json_comments: customization.json
 	python3 -m json.tool customization_no_comments.json > /dev/null
 
 process_grades.out: \
-	${nlohmann_json_dir} \
 	${RAINBOW_GRADES_DIRECTORY}/main.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/output.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/table.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/student.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/zone.cpp \
 	${RAINBOW_GRADES_DIRECTORY}/benchmark.cpp \
-	${RAINBOW_GRADES_DIRECTORY}/submini_polls.cpp
+	${RAINBOW_GRADES_DIRECTORY}/submini_polls.cpp \
+	| ${nlohmann_json_dir}
 	clang++ -Wall -Wextra ${flags} ${memory_flags} ${json_include} $^ -g -o $@
 
 individual_summary_html all_students_summary_csv all_students_summary_html:

--- a/MakefileHelper
+++ b/MakefileHelper
@@ -1,4 +1,4 @@
-.PHONY: default pull push all compile overall section lab hw test quiz final zone clean src_clean remove_json_comments version
+.PHONY: default pull push all compile overall section lab hw test quiz final zone clean src_clean remove_json_comments version tables clean_tables
 
 default: overall
 
@@ -164,5 +164,15 @@ test_exam: compile
 zone: compile
 	./process_grades.out by_zone
 
+SORT_ORDERS ?= by_overall by_section by_hw by_lab by_test by_exam
+
+clean_tables:
+	rm -f output.html output.csv output-by-*.html output-by-*.csv
+
+tables: compile clean_tables
+	@for order in $(SORT_ORDERS); do \
+		echo "=== building table: $$order ==="; \
+		./process_grades.out $$order || exit 1; \
+	done
 
 # =============================================================================

--- a/main.cpp
+++ b/main.cpp
@@ -1864,9 +1864,8 @@ int main(int argc, char* argv[]) {
   std::sort(students.begin(),students.end(),by_overall);
   assign_ranks(students);
   
+  // If there are no gradeables referenced by the sort order, skip this gradeable
   if (!sort_order_is_applicable(GLOBAL_sort_order)) {
-    std::cout << "Skipping " << GLOBAL_sort_order
-              << ": this course has no gradeables of that type." << std::endl;
     return 0;
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1260,7 +1260,7 @@ void load_student_grades(std::vector<Student*> &students) {
         s->setGraded();
       }
     } else if (token == "date_registered") {
-    // parsed by Submitty's grade summaries; not currently used by rainbow grades
+    // gets parsed, not currently used by rainbow grades
     } else if (token == "default_allowed_late_days") {
                   int value = 0;
                   if (!j[token].is_null()) {

--- a/main.cpp
+++ b/main.cpp
@@ -1806,6 +1806,26 @@ std::string output_filename_for(const std::string& sort_order,
   return "./output-by-" + suffix + "." + extension;
 }
 
+bool sort_order_is_applicable(const std::string& sort_order) {
+  if (sort_order == "by_overall" || sort_order == "by_name" || sort_order == "by_section") {
+    return true;
+  }
+  if (sort_order == "by_zone") {
+    return GRADEABLES[GRADEABLE_ENUM::TEST].getCount() > 0;
+  }
+  if (sort_order == "by_test_and_exam") {
+    return GRADEABLES[GRADEABLE_ENUM::TEST].getCount() > 0
+        || GRADEABLES[GRADEABLE_ENUM::EXAM].getCount() > 0;
+  }
+  if (sort_order.size() > 3 && sort_order.substr(0, 3) == "by_") {
+    GRADEABLE_ENUM g;
+    if (string_to_gradeable_enum(sort_order.substr(3), g)) {
+      return GRADEABLES[g].getCount() > 0;
+    }
+  }
+  return true;
+}
+
 int main(int argc, char* argv[]) {
 
   //std::string sort_order = "by_overall";
@@ -1843,7 +1863,12 @@ int main(int argc, char* argv[]) {
   // SORT
   std::sort(students.begin(),students.end(),by_overall);
   assign_ranks(students);
-
+  
+  if (!sort_order_is_applicable(GLOBAL_sort_order)) {
+    std::cout << "Skipping " << GLOBAL_sort_order
+              << ": this course has no gradeables of that type." << std::endl;
+    return 0;
+  }
 
   if (GLOBAL_sort_order == std::string("by_overall")) {
     std::sort(students.begin(),students.end(),by_overall);

--- a/main.cpp
+++ b/main.cpp
@@ -1793,6 +1793,19 @@ void SaveExtensionReports(const std::vector<Student*> &students) {
   }
 }
 
+// Map a sort order to a distinct filename
+std::string output_filename_for(const std::string& sort_order,
+                                const std::string& extension) {
+  if (sort_order.empty() || sort_order == "by_overall") {
+    return "./output." + extension;
+  }
+  std::string suffix = sort_order;
+  if (suffix.substr(0, 3) == "by_") {
+    suffix = suffix.substr(3);
+  }
+  return "./output-by-" + suffix + "." + extension;
+}
+
 int main(int argc, char* argv[]) {
 
   //std::string sort_order = "by_overall";
@@ -1805,6 +1818,9 @@ int main(int argc, char* argv[]) {
   if (argc > 1) {
     assert (argc == 2);
     GLOBAL_sort_order = argv[1];
+  }
+  if (GLOBAL_sort_order.empty()) {
+    GLOBAL_sort_order = "by_overall";
   }
 
   std::vector<Student*> students;  

--- a/main.cpp
+++ b/main.cpp
@@ -1822,6 +1822,8 @@ int main(int argc, char* argv[]) {
   if (GLOBAL_sort_order.empty()) {
     GLOBAL_sort_order = "by_overall";
   }
+  OUTPUT_FILE     = output_filename_for(GLOBAL_sort_order, "html");
+  OUTPUT_CSV_FILE = output_filename_for(GLOBAL_sort_order, "csv");
 
   std::vector<Student*> students;  
   processcustomizationfile(now_string,students);

--- a/main.cpp
+++ b/main.cpp
@@ -1259,6 +1259,8 @@ void load_student_grades(std::vector<Student*> &students) {
         assert (type == "graded");
         s->setGraded();
       }
+    } else if (token == "date_registered") {
+    // parsed by Submitty's grade summaries; not currently used by rainbow grades
     } else if (token == "default_allowed_late_days") {
                   int value = 0;
                   if (!j[token].is_null()) {

--- a/output.cpp
+++ b/output.cpp
@@ -427,7 +427,9 @@ void PrintExamRoomAndZoneTable(const std::string &g_id, nlohmann::json &mj, Stud
 
   // ==============================================================
 
-  if ( DISPLAY_EXAM_SEATING == false) return;
+  if (DISPLAY_EXAM_SEATING == false) return;
+
+  if (GRADEABLES[GRADEABLE_ENUM::TEST].getCount() == 0) return;
 
   std::string room = GLOBAL_EXAM_DEFAULT_ROOM;
   std::string building = GLOBAL_EXAM_DEFAULT_BUILDING;

--- a/output.cpp
+++ b/output.cpp
@@ -1223,14 +1223,14 @@ void start_table_output( bool /*for_instructor*/,
   std::stringstream ss;
 
   if(!csv_mode) {
-      ss << ALL_STUDENTS_OUTPUT_DIRECTORY << "output_" << month << "_" << day << "_" << year << ".html";
-      std::string command = "cp -f output.html " + ss.str();
+      ss << ALL_STUDENTS_OUTPUT_DIRECTORY << "output_" << GLOBAL_sort_order << "_" << month << "_" << day << "_" << year << ".html";
+      std::string command = "cp -f " + OUTPUT_FILE + " " + ss.str();
       std::cout << "RUN COMMAND " << command << std::endl;
       system(command.c_str());
   }
-  else{
-      ss << ALL_STUDENTS_OUTPUT_DIRECTORY_CSV << "output_" << month << "_" << day << "_" << year << ".csv";
-      std::string command = "cp -f output.csv " + ss.str();
+  else {
+      ss << ALL_STUDENTS_OUTPUT_DIRECTORY_CSV << "output_" << GLOBAL_sort_order << "_" << month << "_" << day << "_" << year << ".csv";
+      std::string command = "cp -f " + OUTPUT_CSV_FILE + " " + ss.str();
       std::cout << "RUN COMMAND " << command << std::endl;
       system(command.c_str());
   }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This PR fixes a bug where if a course has no exams and rainbow grades is configured to show the exam seating, the build will fail.

Attached below is the error:
<img width="1361" height="849" alt="image" src="https://github.com/user-attachments/assets/9aa77dfb-def9-4c96-8522-d8ccb96280af" />

### What is the New Behavior?
Now, there is a check added to verify that the course has exam gradeables before attempting to return the exam seating zone.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Checkout this branch
2. Go to the development course's grades configurations
3. Enable exam seating and build
4. See error