### PR TITLE
[Bugfix:RainbowGrades] Add handling for date_registered

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1260,7 +1260,7 @@ void load_student_grades(std::vector<Student*> &students) {
         s->setGraded();
       }
     } else if (token == "date_registered") {
-    // parsed by Submitty's grade summaries; not currently used by rainbow grades
+    // gets parsed, not currently used by rainbow grades
     } else if (token == "default_allowed_late_days") {
                   int value = 0;
                   if (!j[token].is_null()) {

--- a/main.cpp
+++ b/main.cpp
@@ -1259,6 +1259,8 @@ void load_student_grades(std::vector<Student*> &students) {
         assert (type == "graded");
         s->setGraded();
       }
+    } else if (token == "date_registered") {
+    // parsed by Submitty's grade summaries; not currently used by rainbow grades
     } else if (token == "default_allowed_late_days") {
                   int value = 0;
                   if (!j[token].is_null()) {


### PR DESCRIPTION
When [PR#13011](https://github.com/Submitty/Submitty/pull/13011) was merged, a new field, `date_registered`, was added to the users table, which rainbow grades parses. This field causes an unknown token error. This PR adds handling for that field, however it is currently unused. 

To test:
1. Navigate to rainbow grades
2. Check some options
3. Click build
4. Make sure that rainbow grades builds and can be viewed