### PR TITLE
[Bugfix:RainbowGrades] Fix exam seating zone bug

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -429,6 +429,8 @@ void PrintExamRoomAndZoneTable(const std::string &g_id, nlohmann::json &mj, Stud
 
   if ( DISPLAY_EXAM_SEATING == false) return;
 
+  if (GRADEABLES[GRADEABLE_ENUM::TEST].getCount() == 0) return;
+
   std::string room = GLOBAL_EXAM_DEFAULT_ROOM;
   std::string building = GLOBAL_EXAM_DEFAULT_BUILDING;
   std::string zone = "SEE INSTRUCTOR";


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This PR fixes a bug where if a course has no exams and rainbow grades is configured to show the exam seating, the build will fail.

Attached below is the error:
<img width="1361" height="849" alt="image" src="https://github.com/user-attachments/assets/9aa77dfb-def9-4c96-8522-d8ccb96280af" />

### What is the New Behavior?
Now, there is a check added to verify that the course has exam gradeables before attempting to return the exam seating zone.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Checkout this branch
2. Go to the development course's grades configurations
3. Enable exam seating and build
4. See error