### PR TITLE
[Feature:RainbowGrades] Nlohmann version pinning

### DIFF
--- a/MakefileHelper
+++ b/MakefileHelper
@@ -32,13 +32,17 @@ export REPORTS_DIRECTORY
 
 .PHONY: nlohmann_json
 nlohmann_json:
+	@if [ -z "${nlohmann_json_Version}" ]; then \
+		echo "ERROR: nlohmann_json_Version is empty — is versions.mk included and the name spelled exactly?"; \
+		exit 1; \
+	fi
 	@if [ ! -f ${nlohmann_json_dir}/VERSION ] || [ "$$(cat ${nlohmann_json_dir}/VERSION)" != "${nlohmann_json_Version}" ]; then \
-		echo "Fetching nlohmann/json ${nlohmann_json_Version}..."; \
-		mkdir -p ${nlohmann_json_dir}; \
-		rm -rf ${nlohmann_json_dir}/include ${nlohmann_json_dir}/single_include; \
-		wget -nv https://github.com/nlohmann/json/releases/download/${nlohmann_json_Version}/include.zip -O ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip; \
-		unzip -o -q ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip "include/*" -d ${nlohmann_json_dir}; \
-		rm -f ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip; \
+		echo "Fetching nlohmann/json ${nlohmann_json_Version}..." && \
+		mkdir -p ${nlohmann_json_dir} && \
+		rm -rf ${nlohmann_json_dir}/include ${nlohmann_json_dir}/single_include && \
+		curl -fsSL https://github.com/nlohmann/json/releases/download/${nlohmann_json_Version}/include.zip -o ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip && \
+		unzip -o -q ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip "include/*" -d ${nlohmann_json_dir} && \
+		rm -f ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip && \
 		echo "${nlohmann_json_Version}" > ${nlohmann_json_dir}/VERSION; \
 	fi
 

--- a/MakefileHelper
+++ b/MakefileHelper
@@ -24,15 +24,23 @@ ifndef REPORTS_DIRECTORY
 $(error Variable REPORTS_DIRECTORY not set)
 endif
 
-nlohmann_json_dir=${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann/json
+include ${RAINBOW_GRADES_DIRECTORY}/versions.mk
+nlohmann_json_dir = ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann/json
 
 export RAINBOW_GRADES_DIRECTORY
 export REPORTS_DIRECTORY
 
-${nlohmann_json_dir}:
-	mkdir -p ${nlohmann_json_dir}
-	wget https://github.com/nlohmann/json/releases/download/v3.1.2/include.zip -O ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip
-	unzip -o ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip -d ${nlohmann_json_dir}
+.PHONY: nlohmann_json
+nlohmann_json:
+	@if [ ! -f ${nlohmann_json_dir}/VERSION ] || [ "$$(cat ${nlohmann_json_dir}/VERSION)" != "${nlohmann_json_Version}" ]; then \
+		echo "Fetching nlohmann/json ${nlohmann_json_Version}..."; \
+		mkdir -p ${nlohmann_json_dir}; \
+		rm -rf ${nlohmann_json_dir}/include ${nlohmann_json_dir}/single_include; \
+		wget -nv https://github.com/nlohmann/json/releases/download/${nlohmann_json_Version}/include.zip -O ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip; \
+		unzip -o -q ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip "include/*" -d ${nlohmann_json_dir}; \
+		rm -f ${RAINBOW_GRADES_DIRECTORY}/../vendor/nlohmann_json.zip; \
+		echo "${nlohmann_json_Version}" > ${nlohmann_json_dir}/VERSION; \
+	fi
 
 
 # =============================================================================
@@ -118,7 +126,7 @@ all: pull overall push
 # =============================================================================
 # the different sorting orders & details of tables
 
-overall: ${nlohmann_json_dir} ${json_syntax_checker.py} compile
+overall: nlohmann_json ${json_syntax_checker.py} compile
 	./process_grades.out by_overall
 
 memory_debug: compile

--- a/versions.mk
+++ b/versions.mk
@@ -1,0 +1,3 @@
+# Pinned versions of vendored third-party libraries for RainbowGrades.
+# Keep nlohmann_json_Version in sync with Submitty's .setup/bin/versions.sh
+nlohmann_json_Version = v3.12.0


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This PR implements version pinning for the nlohmann-json dependency which previously was pinned at 3.1.2, which would cause errors if someone did not already have the dependency. 

### What is the New Behavior?
A few file called versions.mk has been created which contains the version of nlohmann that is currently pinned. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Delete the vendor folder in GIT_CHECKOUT
2. Run make pull and make
You should see the following output:
<img width="625" height="137" alt="image" src="https://github.com/user-attachments/assets/cd4dedf8-cfb6-4301-ba45-97c7f0b118e0" />

3. Test with the vendor folder present but with an incorrect version installed, the new version should be installed
4. Test in conjunction with submitty_install, the vendor folder should not interfere with the folder created by the submitty repo

### Automated Testing & Documentation
N/A

### Other information
This is not a breaking change
This are no migrations included
Not a security concern