### PR TITLE
[Feature:RainbowGrades] Integrate date registered field

### DIFF
--- a/constants_and_globals.h
+++ b/constants_and_globals.h
@@ -17,6 +17,7 @@ extern bool DISPLAY_GRADE_SUMMARY;
 extern bool DISPLAY_GRADE_DETAILS;
 extern bool DISPLAY_LATE_DAYS;
 extern bool DISPLAY_RANK_TO_INDIVIDUAL;
+extern bool DISPLAY_DATE_REGISTERED;
 
 // ==========================================================
 // messages for zone assignment

--- a/main.cpp
+++ b/main.cpp
@@ -10,6 +10,7 @@
 #include <ctime>
 #include <cmath>
 #include "benchmark.h"
+#include "constants_and_globals.h"
 #include "submini_polls.h"
 
 std::string GLOBAL_sort_order;
@@ -131,7 +132,7 @@ bool DISPLAY_GRADE_SUMMARY = false;
 bool DISPLAY_GRADE_DETAILS = false;
 bool DISPLAY_LATE_DAYS = false;
 bool DISPLAY_RANK_TO_INDIVIDUAL = false;
-
+bool DISPLAY_DATE_REGISTERED = false;
 
 std::vector<std::string> MESSAGES;
 
@@ -382,6 +383,7 @@ void preprocesscustomizationfile(const std::string &now_string,
         DISPLAY_GRADE_SUMMARY = true;
       } else if (token == "grade_details") {
         DISPLAY_GRADE_DETAILS = true;
+
 
       } else {
         std::cout << "OOPS " << token << std::endl;
@@ -784,6 +786,8 @@ void preprocesscustomizationfile(const std::string &now_string,
       DISPLAY_GRADE_DETAILS = true;
     } else if (token == "display_rank_to_individual"){
       DISPLAY_RANK_TO_INDIVIDUAL = true;
+    } else if (token == "date_registered") {
+      DISPLAY_DATE_REGISTERED = true;
     } else if (token == "display_benchmark") {
       continue;
     } else if (token == "section") {
@@ -1260,7 +1264,9 @@ void load_student_grades(std::vector<Student*> &students) {
         s->setGraded();
       }
     } else if (token == "date_registered") {
-    // gets parsed, not currently used by rainbow grades
+      if (!j[token].is_null()) {
+        s->setDateRegistered(j[token].get<std::string>());
+      }
     } else if (token == "default_allowed_late_days") {
                   int value = 0;
                   if (!j[token].is_null()) {

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,6 @@
 #include <ctime>
 #include <cmath>
 #include "benchmark.h"
-#include "constants_and_globals.h"
 #include "submini_polls.h"
 
 std::string GLOBAL_sort_order;

--- a/output.cpp
+++ b/output.cpp
@@ -622,6 +622,9 @@ void start_table_output( bool /*for_instructor*/,
   table.set(0,counter++,TableCell("ffffff","#"));
   table.set(0,counter++,TableCell("ffffff","SECTION"));
   table.set(0,counter++,TableCell("ffffff","reg type"));
+  if (DISPLAY_DATE_REGISTERED) {
+    table.set(0,counter++,TableCell("ffffff","reg date"));
+  }
   if (DISPLAY_INSTRUCTOR_NOTES) {
     table.set(0,counter++,TableCell("ffffff","part."));
     table.set(0,counter++,TableCell("ffffff","under."));
@@ -854,6 +857,10 @@ void start_table_output( bool /*for_instructor*/,
     assert (section_color.size()==6);
     table.set(myrow,counter++,TableCell(section_color,section_label));
     table.set(myrow,counter++,TableCell(default_color,status));
+
+    if (DISPLAY_DATE_REGISTERED) {
+      table.set(myrow,counter++,TableCell(default_color,this_student->getDateRegisteredShort()));
+    }
 
     if (DISPLAY_INSTRUCTOR_NOTES) {
       float participation = this_student->getParticipation();

--- a/student.h
+++ b/student.h
@@ -115,7 +115,6 @@ public:
   }
 
   const std::string& getDateRegistered() const { return date_registered; }
-  // ISO-8601 from Submitty; the date half is what's worth showing
   std::string getDateRegisteredShort() const {
     return date_registered.substr(0, date_registered.find('T'));
   }

--- a/student.h
+++ b/student.h
@@ -114,6 +114,12 @@ public:
     return "other";
   }
 
+  const std::string& getDateRegistered() const { return date_registered; }
+  // ISO-8601 from Submitty; the date half is what's worth showing
+  std::string getDateRegisteredShort() const {
+    return date_registered.substr(0, date_registered.find('T'));
+  }
+
   // grade data
   const ItemGrade& getGradeableItemGrade(GRADEABLE_ENUM g, int i) const;
   std::string getZone(int i) const;
@@ -186,6 +192,7 @@ public:
   void setWithdrawn() { withdrawn = true; }
   void setGraded() { graded = true; }
   void setIndependentStudy() { independentstudy = true; }
+  void setDateRegistered(const std::string &x) { date_registered = x; }
 
   // grade data
   void setTestZone(int which_test, const std::string &zone)  { zones[which_test] = zone; }
@@ -280,6 +287,7 @@ private:
     // registration status
   std::string section;
   std::string course_section_id;
+  std::string date_registered;
   int rotating_section;
   bool audit;
   bool withdrawn;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes [Issue#11547](https://github.com/Submitty/Submitty/issues/11547)
When testing, checkout Submitty [PR#13096](https://github.com/Submitty/Submitty/pull/13096) as well.

### What is the New Behavior?
This PR adds integration of the date_registered field which was previously handled but not integrated. Now, the table will output a date registered field and also add it to the CSV that can be downloaded from the Submitty UI.

Refer to the linked PR in the Submitty repo for testing instructions. 